### PR TITLE
chore: rename Docker image references from nomad to trek

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=mauriceboe/nomad,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=mauriceboe/trek,push-by-digest=true,name-canonical=true,push=true
           no-cache: true
 
       - name: Export digest
@@ -79,8 +79,8 @@ jobs:
       - name: Create and push multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          mapfile -t digests < <(printf 'mauriceboe/nomad@sha256:%s\n' *)
-          docker buildx imagetools create -t mauriceboe/nomad:latest -t mauriceboe/nomad:${{ steps.version.outputs.VERSION }} "${digests[@]}"
+          mapfile -t digests < <(printf 'mauriceboe/trek@sha256:%s\n' *)
+          docker buildx imagetools create -t mauriceboe/trek:latest -t mauriceboe/trek:${{ steps.version.outputs.VERSION }} "${digests[@]}"
 
       - name: Inspect manifest
-        run: docker buildx imagetools inspect mauriceboe/nomad:latest
+        run: docker buildx imagetools inspect mauriceboe/trek:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: mauriceboe/nomad:latest
+    image: mauriceboe/trek:latest
     container_name: trek
     ports:
       - "3000:3000"


### PR DESCRIPTION
Following the upstream rebrand from NOMAD → TREK, the Docker image name published to Docker Hub should also be updated to reflect the new name.

## Changes

- **`.github/workflows/docker.yml`**: Updated all `mauriceboe/nomad` references to `mauriceboe/trek` (build output target, multi-arch manifest creation, version tagging, and inspect step)
- **`docker-compose.yml`**: Updated `image: mauriceboe/nomad:latest` → `image: mauriceboe/trek:latest`

## Notes

The `Dockerfile` itself had no image name references so no changes were needed there.

This keeps the Docker Hub image name consistent with the repository rename.