### PR TITLE
fix: resolve static asset SSL errors from helmet's upgrade-insecure-requests

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,6 +44,8 @@ if (allowedOrigins) {
   corsOrigin = true;
 }
 
+const shouldForceHttps = process.env.FORCE_HTTPS === 'true';
+
 app.use(cors({
   origin: corsOrigin,
   credentials: true
@@ -60,13 +62,15 @@ app.use(helmet({
       objectSrc: ["'self'"],
       frameSrc: ["'self'"],
       frameAncestors: ["'self'"],
+      upgradeInsecureRequests: shouldForceHttps ? [] : null
     }
   },
   crossOriginEmbedderPolicy: false,
-  hsts: process.env.FORCE_HTTPS === 'true' ? { maxAge: 31536000, includeSubDomains: false } : false,
+  hsts: shouldForceHttps ? { maxAge: 31536000, includeSubDomains: false } : false,
 }));
+
 // Redirect HTTP to HTTPS (opt-in via FORCE_HTTPS=true)
-if (process.env.FORCE_HTTPS === 'true') {
+if (shouldForceHttps) {
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (req.secure || req.headers['x-forwarded-proto'] === 'https') return next();
     res.redirect(301, 'https://' + req.headers.host + req.url);


### PR DESCRIPTION
Helmet merges default CSP directives (including `upgrade-insecure-requests`) into custom directives when `useDefaults` is true (the default). This caused browsers to upgrade all HTTP sub-resource requests to HTTPS, breaking static assets when the server runs over plain HTTP.

This commit conditionally sets `upgrade-insecure-requests` based on FORCE_HTTPS: enabled in production (where HTTPS is available), explicitly disabled (null) otherwise to prevent browser SSL errors on home servers and development environments.

Also extracts `shouldForceHttps` to avoid repeated env lookups.

| Before | After |
|--------|--------|
|<img width="925" height="243" alt="image" src="https://github.com/user-attachments/assets/5f826466-a58d-4e21-847f-3cb260e01e56" /> | <img width="898" height="226" alt="image" src="https://github.com/user-attachments/assets/5389fa32-5a98-460a-92ce-5a1975586c8a" />| 
