### PR TITLE
fix: prioritize ADM0_A3 over ISO_A3 in atlas area resolution to support France, Norway and Israel

### DIFF
--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -241,7 +241,7 @@ export default function AtlasPage(): React.ReactElement {
       interactive: true,
       bubblingMouseEvents: false,
       style: (feature) => {
-        const a3 = feature.properties?.ISO_A3 || feature.properties?.ADM0_A3 || feature.properties?.['ISO3166-1-Alpha-3'] || feature.id
+        const a3 = feature.properties?.ADM0_A3 || feature.properties?.ISO_A3 || feature.properties?.['ISO3166-1-Alpha-3'] || feature.id
         const visited = visitedA3.has(a3)
         return {
           fillColor: visited ? colorForCode(a3) : (dark ? '#1e1e2e' : '#e2e8f0'),
@@ -251,7 +251,7 @@ export default function AtlasPage(): React.ReactElement {
         }
       },
       onEachFeature: (feature, layer) => {
-        const a3 = feature.properties?.ISO_A3 || feature.properties?.ADM0_A3 || feature.properties?.['ISO3166-1-Alpha-3'] || feature.id
+        const a3 = feature.properties?.ADM0_A3 || feature.properties?.ISO_A3 || feature.properties?.['ISO3166-1-Alpha-3'] || feature.id
         const c = countryMap[a3]
         if (c) {
           const name = resolveName(c.code)


### PR DESCRIPTION
I noticed that France isn't displayed in the atlas when you've been there. As far as I can tell, this is because `feature.properties?.ISO_A3` returns -99 as the country point at this point instead of FRA. `feature.properties?.ADM0_A3` returns the correct value.

While testing, I noticed that the same issue existed for Norway and Israel. These countries are now displayed as well. 

For all other countries, ISO_A3 and ADM0_A3 match. I have therefore prioritized ADM0_A3 over ISO_A3 to fix the error with these three countries.