### PR TITLE
feat(client): add time of day groupings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm
+
+# better-sqlite3 and other native npm modules
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends build-essential python3 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "TREK",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "forwardPorts": [5173, 3001],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite (client)",
+      "onAutoForward": "notify"
+    },
+    "3001": {
+      "label": "API (Express)",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "bash -c 'test -f server/.env || cp server/.env.example server/.env; npm ci --prefix server && npm ci --prefix client'",
+  "postStartCommand": "bash -c 'nohup npm run dev --prefix server >/tmp/trek-server-dev.log 2>&1 & nohup npm run dev --prefix client >/tmp/trek-client-dev.log 2>&1 &'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bradlc.vscode-tailwindcss"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "PORT": "3001",
+    "NODE_ENV": "development"
+  }
+}

--- a/client/src/components/PDF/TripPDF.tsx
+++ b/client/src/components/PDF/TripPDF.tsx
@@ -3,7 +3,13 @@ import { createElement } from 'react'
 import { getCategoryIcon } from '../shared/categoryIcons'
 import { FileText, Info, Clock, MapPin, Navigation, Train, Plane, Bus, Car, Ship, Coffee, Ticket, Star, Heart, Camera, Flag, Lightbulb, AlertTriangle, ShoppingBag, Bookmark } from 'lucide-react'
 import { mapsApi } from '../../api/client'
-import type { Trip, Day, Place, Category, AssignmentsMap, DayNotesMap } from '../../types'
+import type { Trip, Day, Place, Category, AssignmentsMap, DayNotesMap, Reservation, DayNote } from '../../types'
+import {
+  sortMergedByTimeOfDayIfNeeded,
+  getMergedItemTimeMeta,
+  timeBucketLabel,
+  type MergedPlanItem,
+} from '../../utils/dayPlanTimeGroups'
 
 const NOTE_ICON_MAP = { FileText, Info, Clock, MapPin, Navigation, Train, Plane, Bus, Car, Ship, Coffee, Ticket, Star, Heart, Camera, Flag, Lightbulb, AlertTriangle, ShoppingBag, Bookmark }
 function noteIconSvg(iconId) {
@@ -95,15 +101,35 @@ interface downloadTripPDFProps {
   places: Place[]
   assignments: AssignmentsMap
   categories: Category[]
-  dayNotes: DayNotesMap
+  dayNotes: DayNotesMap | (DayNote & { day_id: number })[]
+  reservations?: Reservation[]
   t: (key: string, params?: Record<string, string | number>) => string
   locale: string
 }
 
-export async function downloadTripPDF({ trip, days, places, assignments, categories, dayNotes, t: _t, locale: _locale }: downloadTripPDFProps) {
+function flattenDayNotesForPdf(dayNotes: DayNotesMap | (DayNote & { day_id: number })[]): (DayNote & { day_id: number })[] {
+  if (Array.isArray(dayNotes)) return dayNotes
+  return Object.entries(dayNotes || {}).flatMap(([dayId, notes]) =>
+    ((notes as DayNote[] | undefined) || []).map((n) => ({ ...n, day_id: Number(dayId) }))
+  )
+}
+
+export async function downloadTripPDF({
+  trip,
+  days,
+  places,
+  assignments,
+  categories,
+  dayNotes,
+  reservations = [],
+  t: _t,
+  locale: _locale,
+}: downloadTripPDFProps) {
   await ensureRenderer()
   const loc = _locale || 'de-DE'
-  const tr = _t || (k => k)
+  const tr = _t || ((k: string) => k)
+  const resList = reservations || []
+  const notesFlat = flattenDayNotesForPdf(dayNotes)
   const sorted = [...(days || [])].sort((a, b) => a.day_number - b.day_number)
   const range = longDateRange(sorted, loc)
   const coverImg = safeImg(trip?.cover_image)
@@ -120,21 +146,34 @@ export async function downloadTripPDF({ trip, days, places, assignments, categor
   // Build day HTML
   const daysHtml = sorted.map((day, di) => {
     const assigned = assignments[String(day.id)] || []
-    const notes = (dayNotes || []).filter(n => n.day_id === day.id)
+    const notes = notesFlat.filter(n => n.day_id === day.id)
     const cost = dayCost(assignments, day.id, loc)
 
-    const merged = []
-    assigned.forEach(a => merged.push({ type: 'place', k: a.order_index ?? a.sort_order ?? 0, data: a }))
-    notes.forEach(n    => merged.push({ type: 'note',  k: n.sort_order ?? 0, data: n }))
-    merged.sort((a, b) => a.k - b.k)
+    const raw: MergedPlanItem[] = [
+      ...assigned.map((a) => ({ type: 'place' as const, sortKey: a.order_index ?? 0, data: a })),
+      ...notes.map((n) => ({ type: 'note' as const, sortKey: n.sort_order ?? 0, data: n })),
+    ].sort((a, b) => a.sortKey - b.sortKey)
+    const merged = sortMergedByTimeOfDayIfNeeded(raw, resList)
+    const mergedTimeMetas = merged.map((item) => getMergedItemTimeMeta(item, resList))
+    const hasAnyTimedInDay = mergedTimeMetas.some((m) => m.bucket > 0)
 
     let pi = 0
     const itemsHtml = merged.length === 0
       ? `<div class="empty-day">${escHtml(tr('dayplan.emptyDay'))}</div>`
-      : merged.map(item => {
+      : merged.map((item, idx) => {
+          const timeMeta = mergedTimeMetas[idx]
+          const prevTimeMeta = idx > 0 ? mergedTimeMetas[idx - 1] : null
+          const showTimeSectionHeader =
+            hasAnyTimedInDay &&
+            timeMeta.bucket > 0 &&
+            (idx === 0 || (prevTimeMeta && prevTimeMeta.bucket !== timeMeta.bucket))
+          const sectionHeaderHtml = showTimeSectionHeader
+            ? `<div class="time-section-label">${escHtml(timeBucketLabel(timeMeta.bucket, tr))}</div>`
+            : ''
+
           if (item.type === 'note') {
             const note = item.data
-            return `
+            return `${sectionHeaderHtml}
               <div class="note-card">
                 <div class="note-line"></div>
                 <span class="note-icon">${noteIconSvg(note.icon)}</span>
@@ -168,7 +207,7 @@ export async function downloadTripPDF({ trip, days, places, assignments, categor
             place.price && parseFloat(place.price) > 0 ? `<span class="chip chip-green">${svgEuro}${Number(place.price).toLocaleString(loc)} EUR</span>` : '',
           ].filter(Boolean).join('')
 
-          return `
+          return `${sectionHeaderHtml}
             <div class="place-card">
               <div class="place-bar" style="background:${color}"></div>
               ${thumbHtml}
@@ -277,6 +316,12 @@ export async function downloadTripPDF({ trip, days, places, assignments, categor
   .day-date  { font-size: 9px; color: rgba(255,255,255,0.45); }
   .day-cost  { font-size: 9px; font-weight: 600; color: rgba(255,255,255,0.65); }
   .day-body  { padding: 12px 28px 6px; }
+
+  .time-section-label {
+    font-size: 8px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+    color: #94a3b8; padding: 10px 0 4px; margin-top: 2px;
+  }
+  .day-body > .time-section-label:first-child { padding-top: 0; margin-top: 0; }
 
   /* ── Place card ────────────────────────────────── */
   .place-card {

--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -18,8 +18,14 @@ import { useTripStore } from '../../store/tripStore'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useTranslation } from '../../i18n'
 import { formatDate, formatTime, dayTotalCost, currencyDecimals } from '../../utils/formatters'
+import {
+  sortMergedByTimeOfDayIfNeeded,
+  getMergedItemTimeMeta,
+  timeBucketLabel,
+  type MergedPlanItem,
+} from '../../utils/dayPlanTimeGroups'
 import { useDayNotes } from '../../hooks/useDayNotes'
-import type { Trip, Day, Place, Category, Assignment, Reservation, AssignmentsMap, RouteResult } from '../../types'
+import type { Trip, Day, Place, Category, Assignment, Reservation, AssignmentsMap, RouteResult, MergedItem } from '../../types'
 
 const NOTE_ICONS = [
   { id: 'FileText', Icon: FileText },
@@ -182,15 +188,16 @@ export default function DayPlanSidebar({
   const getMergedItems = (dayId) => {
     const da = getDayAssignments(dayId)
     const dn = (dayNotes[String(dayId)] || []).slice().sort((a, b) => a.sort_order - b.sort_order)
-    return [
-      ...da.map(a => ({ type: 'place', sortKey: a.order_index, data: a })),
-      ...dn.map(n => ({ type: 'note', sortKey: n.sort_order, data: n })),
+    const raw: MergedPlanItem[] = [
+      ...da.map(a => ({ type: 'place' as const, sortKey: a.order_index, data: a })),
+      ...dn.map(n => ({ type: 'note' as const, sortKey: n.sort_order, data: n })),
     ].sort((a, b) => a.sortKey - b.sortKey)
+    return sortMergedByTimeOfDayIfNeeded(raw, reservations)
   }
 
   const openAddNote = (dayId, e) => {
     e?.stopPropagation()
-    _openAddNote(dayId, getMergedItems, (id) => {
+    _openAddNote(dayId, getMergedItems as (id: number) => MergedItem[], (id) => {
       if (!expandedDays.has(id)) setExpandedDays(prev => new Set([...prev, id]))
     })
   }
@@ -249,7 +256,7 @@ export default function DayPlanSidebar({
   }
 
   const moveNote = async (dayId, noteId, direction) => {
-    await _moveNote(dayId, noteId, direction, getMergedItems)
+    await _moveNote(dayId, noteId, direction, getMergedItems as (id: number) => MergedItem[])
   }
 
   const startEditTitle = (day, e) => {
@@ -396,7 +403,7 @@ export default function DayPlanSidebar({
                 notes.map(n => ({ ...n, day_id: Number(dayId) }))
               )
               try {
-                await downloadTripPDF({ trip, days, places, assignments, categories, dayNotes: flatNotes, t, locale })
+                await downloadTripPDF({ trip, days, places, assignments, categories, dayNotes: flatNotes, reservations, t, locale })
               } catch (e) {
                 console.error('PDF error:', e)
                 toast.error(t('dayplan.pdfError') + ': ' + (e?.message || String(e)))
@@ -427,6 +434,8 @@ export default function DayPlanSidebar({
           const loc = da.find(a => a.place?.lat && a.place?.lng)
           const isDragTarget = dragOverDayId === day.id
           const merged = getMergedItems(day.id)
+          const mergedTimeMetas = merged.map((item) => getMergedItemTimeMeta(item, reservations))
+          const hasAnyTimedInDay = mergedTimeMetas.some((m) => m.bucket > 0)
           const dayNoteUi = noteUi[day.id]
           const placeItems = merged.filter(i => i.type === 'place')
 
@@ -579,6 +588,12 @@ export default function DayPlanSidebar({
                     merged.map((item, idx) => {
                       const itemKey = item.type === 'place' ? `place-${item.data.id}` : `note-${item.data.id}`
                       const showDropLine = (!!draggingId || !!dropTargetKey) && dropTargetKey === itemKey
+                      const timeMeta = mergedTimeMetas[idx]
+                      const prevTimeMeta = idx > 0 ? mergedTimeMetas[idx - 1] : null
+                      const showTimeSectionHeader =
+                        hasAnyTimedInDay &&
+                        timeMeta.bucket > 0 &&
+                        (idx === 0 || (prevTimeMeta && prevTimeMeta.bucket !== timeMeta.bucket))
 
                       if (item.type === 'place') {
                         const assignment = item.data
@@ -608,6 +623,20 @@ export default function DayPlanSidebar({
                         return (
                           <React.Fragment key={`place-${assignment.id}`}>
                             {showDropLine && <div style={{ height: 2, background: 'var(--text-primary)', borderRadius: 1, margin: '2px 8px' }} />}
+                            {showTimeSectionHeader && (
+                              <div
+                                style={{
+                                  padding: '8px 16px 4px',
+                                  fontSize: 10,
+                                  fontWeight: 700,
+                                  letterSpacing: '0.06em',
+                                  textTransform: 'uppercase',
+                                  color: 'var(--text-faint)',
+                                }}
+                              >
+                                {timeBucketLabel(timeMeta.bucket, t)}
+                              </div>
+                            )}
                           <div
                             draggable
                             onDragStart={e => {
@@ -793,6 +822,20 @@ export default function DayPlanSidebar({
                       return (
                         <React.Fragment key={`note-${note.id}`}>
                           {showDropLine && <div style={{ height: 2, background: 'var(--text-primary)', borderRadius: 1, margin: '2px 8px' }} />}
+                          {showTimeSectionHeader && (
+                            <div
+                              style={{
+                                padding: '8px 16px 4px',
+                                fontSize: 10,
+                                fontWeight: 700,
+                                letterSpacing: '0.06em',
+                                textTransform: 'uppercase',
+                                color: 'var(--text-faint)',
+                              }}
+                            >
+                              {timeBucketLabel(timeMeta.bucket, t)}
+                            </div>
+                          )}
                         <div
                           draggable
                           onDragStart={e => { e.dataTransfer.setData('noteId', String(note.id)); e.dataTransfer.setData('fromDayId', String(day.id)); e.dataTransfer.effectAllowed = 'move'; dragDataRef.current = { noteId: String(note.id), fromDayId: String(day.id) }; setDraggingId(`note-${note.id}`) }}

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -535,6 +535,9 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Tagesplan als PDF exportieren',
   'dayplan.pdfError': 'Fehler beim PDF-Export',
+  'dayplan.timeMorning': 'Morgen',
+  'dayplan.timeAfternoon': 'Nachmittag',
+  'dayplan.timeEvening': 'Abend',
 
   // Places Sidebar
   'places.addPlace': 'Ort/Aktivität hinzufügen',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -535,6 +535,9 @@ const en: Record<string, string | { name: string; category: string }[]> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Export day plan as PDF',
   'dayplan.pdfError': 'Failed to export PDF',
+  'dayplan.timeMorning': 'Morning',
+  'dayplan.timeAfternoon': 'Afternoon',
+  'dayplan.timeEvening': 'Evening',
 
   // Places Sidebar
   'places.addPlace': 'Add Place/Activity',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -511,6 +511,9 @@ const es: Record<string, string> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Exportar plan diario como PDF',
   'dayplan.pdfError': 'No se pudo exportar el PDF',
+  'dayplan.timeMorning': 'Mañana',
+  'dayplan.timeAfternoon': 'Tarde',
+  'dayplan.timeEvening': 'Noche',
 
   // Places Sidebar
   'places.addPlace': 'Añadir lugar/actividad',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -531,6 +531,9 @@ const fr: Record<string, string> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Exporter le plan du jour en PDF',
   'dayplan.pdfError': 'Échec de l\'export PDF',
+  'dayplan.timeMorning': 'Matin',
+  'dayplan.timeAfternoon': 'Après-midi',
+  'dayplan.timeEvening': 'Soir',
 
   // Places Sidebar
   'places.addPlace': 'Ajouter un lieu/activité',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -531,6 +531,9 @@ const nl: Record<string, string> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Dagplan exporteren als PDF',
   'dayplan.pdfError': 'PDF-export mislukt',
+  'dayplan.timeMorning': 'Ochtend',
+  'dayplan.timeAfternoon': 'Middag',
+  'dayplan.timeEvening': 'Avond',
 
   // Places Sidebar
   'places.addPlace': 'Plaats/activiteit toevoegen',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -531,6 +531,9 @@ const ru: Record<string, string> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': 'Экспортировать план дня в PDF',
   'dayplan.pdfError': 'Ошибка экспорта PDF',
+  'dayplan.timeMorning': 'Утро',
+  'dayplan.timeAfternoon': 'День',
+  'dayplan.timeEvening': 'Вечер',
 
   // Places Sidebar
   'places.addPlace': 'Добавить место/активность',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -531,6 +531,9 @@ const zh: Record<string, string> = {
   'dayplan.pdf': 'PDF',
   'dayplan.pdfTooltip': '导出当天计划为 PDF',
   'dayplan.pdfError': 'PDF 导出失败',
+  'dayplan.timeMorning': '上午',
+  'dayplan.timeAfternoon': '下午',
+  'dayplan.timeEvening': '晚上',
 
   // Places Sidebar
   'places.addPlace': '添加地点/活动',

--- a/client/src/utils/dayPlanTimeGroups.ts
+++ b/client/src/utils/dayPlanTimeGroups.ts
@@ -1,0 +1,89 @@
+import type { Assignment, DayNote, Reservation } from '../types'
+
+export type MergedPlanItem =
+  | { type: 'place'; sortKey: number; data: Assignment }
+  | { type: 'note'; sortKey: number; data: DayNote }
+
+export type TimeBucket = 0 | 1 | 2 | 3
+
+type ReservationWithAssignment = Reservation & { assignment_id?: number; reservation_time?: string }
+
+export function parseHHMMToMinutes(s: string | null | undefined): number | null {
+  if (!s || typeof s !== 'string') return null
+  const parts = s.trim().split(':')
+  if (parts.length < 2) return null
+  const h = Number(parts[0])
+  const m = Number(parts[1])
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return null
+  if (h < 0 || h > 23 || m < 0 || m > 59) return null
+  return h * 60 + m
+}
+
+export function parseNoteTimeMinutes(s: string | null | undefined): number | null {
+  if (!s || typeof s !== 'string') return null
+  const match = s.match(/\b(\d{1,2}):(\d{2})\b/)
+  if (!match) return null
+  const h = Number(match[1])
+  const m = Number(match[2])
+  if (h < 0 || h > 23 || m < 0 || m > 59) return null
+  return h * 60 + m
+}
+
+/** Morning 5:00–11:59, afternoon 12:00–16:59, evening otherwise (incl. night / early hours). */
+export function minutesToBucket(mins: number): 1 | 2 | 3 {
+  if (mins >= 300 && mins < 720) return 1
+  if (mins >= 720 && mins < 1020) return 2
+  return 3
+}
+
+export function getMergedItemTimeMeta(
+  item: MergedPlanItem,
+  reservations: Reservation[]
+): { bucket: TimeBucket; minutes: number; sortKey: number } {
+  const sortKey = item.sortKey
+  if (item.type === 'place') {
+    const a = item.data
+    let mins = parseHHMMToMinutes(a.place?.place_time)
+    if (mins == null) {
+      const res = reservations.find((r) => (r as ReservationWithAssignment).assignment_id === a.id) as
+        | ReservationWithAssignment
+        | undefined
+      const rt = res?.reservation_time
+      if (rt?.includes('T')) {
+        try {
+          const d = new Date(rt)
+          mins = d.getHours() * 60 + d.getMinutes()
+        } catch { /* ignore */ }
+      }
+    }
+    if (mins == null) return { bucket: 0, minutes: 0, sortKey }
+    return { bucket: minutesToBucket(mins), minutes: mins, sortKey }
+  }
+  const mins = parseNoteTimeMinutes(item.data.time)
+  if (mins == null) return { bucket: 0, minutes: 0, sortKey }
+  return { bucket: minutesToBucket(mins), minutes: mins, sortKey }
+}
+
+export function sortMergedByTimeOfDayIfNeeded(merged: MergedPlanItem[], reservations: Reservation[]): MergedPlanItem[] {
+  const metas = merged.map((item) => getMergedItemTimeMeta(item, reservations))
+  const hasAnyTimed = metas.some((m) => m.bucket > 0)
+  if (!hasAnyTimed) return merged
+  const decorated = merged.map((item, index) => ({ item, meta: metas[index], index }))
+  decorated.sort((A, B) => {
+    const ta = A.meta.bucket > 0
+    const tb = B.meta.bucket > 0
+    if (!ta && !tb) return A.item.sortKey - B.item.sortKey || A.index - B.index
+    if (!ta && tb) return -1
+    if (ta && !tb) return 1
+    if (A.meta.bucket !== B.meta.bucket) return A.meta.bucket - B.meta.bucket
+    if (A.meta.minutes !== B.meta.minutes) return A.meta.minutes - B.meta.minutes
+    return A.item.sortKey - B.item.sortKey || A.index - B.index
+  })
+  return decorated.map((d) => d.item)
+}
+
+export function timeBucketLabel(bucket: TimeBucket, t: (key: string) => string): string {
+  if (bucket === 1) return t('dayplan.timeMorning')
+  if (bucket === 2) return t('dayplan.timeAfternoon')
+  return t('dayplan.timeEvening')
+}


### PR DESCRIPTION
Started to use this to plan out our trip to Japan next month. I think I really useful feature would be to group planed activities by morning / afternoon / evening. 

### Behavior
If nothing on that day has a time, the list stays in the existing manual order (same as before).

If anything has a time, items are ordered as:

- No time – places/notes without a usable time stay at the top, in their previous order.
- Morning – 5:00–11:59
- Afternoon – 12:00–16:59
- Evening – everything else (17:00–23:59 and 0:00–4:59)

Within each band, items are sorted by clock time, then by the existing order / sort fields.

### Where times come from
- **Places**:` place.place_time `(HH:MM). If that’s empty, the linked reservation reservation_time (ISO with T) is used, same idea as the rest of the sidebar.
- **Notes**: first `HH:MM` match in the note’s time text (e.g. Meet 14:30 → 14:30).
UI

When at least one item on the day is timed, Morning / Afternoon / Evening labels (translated) are shown when the list moves into that band.

I've also added this to the PDF summary too.

Additionally, I've created a .devcontainer config which might be useful.

<img width="1344" height="1008" alt="image" src="https://github.com/user-attachments/assets/f1c4d887-cded-426e-bc0d-782c97cc897d" />
