### PR TITLE
Prevent duplicate place assignment when dragging to an empty day

### DIFF
--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -632,6 +632,7 @@ export default function DayPlanSidebar({
 
   const handleDropOnDay = (e, dayId) => {
     e.preventDefault()
+    e.stopPropagation()
     setDragOverDayId(null)
     const { placeId, assignmentId, noteId, fromDayId } = getDragData(e)
     if (placeId) {
@@ -886,6 +887,7 @@ export default function DayPlanSidebar({
                   onDragOver={e => { e.preventDefault(); const cur = dropTargetRef.current; if (draggingId && (!cur || cur.startsWith('end-'))) setDropTargetKey(`end-${day.id}`) }}
                   onDrop={e => {
                     e.preventDefault()
+                    e.stopPropagation()
                     const { placeId, assignmentId, noteId, fromDayId } = getDragData(e)
                     // Drop on transport card (detected via dropTargetRef for sync accuracy)
                     if (dropTargetRef.current?.startsWith('transport-')) {


### PR DESCRIPTION
The bug:

When dragging a place from the sidebar onto an expanded, empty day in the planner, the place was being assigned twice — two rows in the database, two cards rendered.

Technical explanation:

The expanded day content area and its empty-day placeholder are nested in the DOM:
```html
<div onDrop={inlineHandler}>       <!-- expanded content area -->
    <div onDrop={handleDropOnDay}>   <!-- empty-day placeholder (shown when day has no items) -->
    </div>
  </div>
```

When a place was dropped on the placeholder, the drop event fired on it first (calling onAssignToDay), then bubbled up to the parent expanded content area, whose own onDrop also called onAssignToDay. One user action, two API calls, two assignments created.

This only happened on empty days because drop handlers on non-empty day items (assignment rows, end-of-day zone) already had e.stopPropagation() — the empty-day placeholder was the one case missing it.

The actual fix:

Added e.stopPropagation() to handleDropOnDay (used by the empty-day placeholder) and to the expanded content area's onDrop handler, consistent with how all other inner drop handlers in the same component already behave.