### PR TITLE
fix: force IPv4 for weather API requests to prevent ETIMEDOUT on Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       # - ALLOWED_ORIGINS=https://yourdomain.com  # Optional: restrict CORS to specific origins
       - PORT=3000
       - TZ=${TZ:-UTC}
+      - NODE_OPTIONS=--dns-result-order=ipv4first
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads

--- a/server/src/routes/weather.ts
+++ b/server/src/routes/weather.ts
@@ -1,8 +1,13 @@
 import express, { Request, Response } from 'express';
+import https from 'https';
 import fetch from 'node-fetch';
 import { authenticate } from '../middleware/auth';
 
 const router = express.Router();
+
+// Force IPv4 to prevent ETIMEDOUT on Docker bridge networks where IPv6 is unroutable.
+// node-fetch v2 ignores NODE_OPTIONS --dns-result-order, so we must pass an explicit agent.
+const ipv4Agent = new https.Agent({ family: 4 });
 
 interface WeatherResult {
   temp: number;
@@ -161,7 +166,7 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
 
       if (diffDays >= -1 && diffDays <= 16) {
         const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&daily=temperature_2m_max,temperature_2m_min,weathercode&timezone=auto&forecast_days=16`;
-        const response = await fetch(url);
+        const response = await fetch(url, { agent: ipv4Agent });
         const data = await response.json() as OpenMeteoForecast;
 
         if (!response.ok || data.error) {
@@ -199,7 +204,7 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
         const endStr = endDate.toISOString().slice(0, 10);
 
         const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lng}&start_date=${startStr}&end_date=${endStr}&daily=temperature_2m_max,temperature_2m_min,precipitation_sum&timezone=auto`;
-        const response = await fetch(url);
+        const response = await fetch(url, { agent: ipv4Agent });
         const data = await response.json() as OpenMeteoForecast;
 
         if (!response.ok || data.error) {
@@ -251,7 +256,7 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
     if (cached) return res.json(cached);
 
     const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=temperature_2m,weathercode&timezone=auto`;
-    const response = await fetch(url);
+    const response = await fetch(url, { agent: ipv4Agent });
     const data = await response.json() as OpenMeteoForecast;
 
     if (!response.ok || data.error) {
@@ -304,7 +309,7 @@ router.get('/detailed', authenticate, async (req: Request, res: Response) => {
         + `&hourly=temperature_2m,precipitation,weathercode,windspeed_10m,relativehumidity_2m`
         + `&daily=temperature_2m_max,temperature_2m_min,weathercode,precipitation_sum,windspeed_10m_max,sunrise,sunset`
         + `&timezone=auto`;
-      const response = await fetch(url);
+      const response = await fetch(url, { agent: ipv4Agent });
       const data = await response.json() as OpenMeteoForecast;
 
       if (!response.ok || data.error) {
@@ -366,7 +371,7 @@ router.get('/detailed', authenticate, async (req: Request, res: Response) => {
       + `&daily=temperature_2m_max,temperature_2m_min,weathercode,sunrise,sunset,precipitation_probability_max,precipitation_sum,windspeed_10m_max`
       + `&timezone=auto&start_date=${dateStr}&end_date=${dateStr}`;
 
-    const response = await fetch(url);
+    const response = await fetch(url, { agent: ipv4Agent });
     const data = await response.json() as OpenMeteoForecast;
 
     if (!response.ok || data.error) {


### PR DESCRIPTION
node-fetch v2 ignores NODE_OPTIONS --dns-result-order=ipv4first because it creates its own HTTPS agent. On Docker bridge networks where IPv6 cannot route to the internet, every outbound request hangs until TCP timeout.

- Add custom https.Agent({ family: 4 }) passed to all open-meteo fetch calls
- Add NODE_OPTIONS=--dns-result-order=ipv4first to docker-compose as defence in depth

Replacing PR https://github.com/mauriceboe/TREK/pull/180