### PR TITLE
fix: remove node-fetch, use native fetch (Node 22)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,6 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
         "node-cron": "^4.2.1",
-        "node-fetch": "^2.7.0",
         "nodemailer": "^8.0.4",
         "otplib": "^12.0.1",
         "qrcode": "^1.5.4",
@@ -3019,26 +3018,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3978,12 +3957,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -4127,22 +4100,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,6 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "node-cron": "^4.2.1",
-    "node-fetch": "^2.7.0",
     "nodemailer": "^8.0.4",
     "otplib": "^12.0.1",
     "qrcode": "^1.5.4",

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import { v4 as uuid } from 'uuid';
-import fetch from 'node-fetch';
+
 import { authenticator } from 'otplib';
 import QRCode from 'qrcode';
 import { db } from '../db/database';

--- a/server/src/routes/collab.ts
+++ b/server/src/routes/collab.ts
@@ -493,11 +493,10 @@ router.get('/link-preview', authenticate, async (req: Request, res: Response) =>
       return res.status(400).json({ error: 'Private/internal URLs are not allowed' });
     }
 
-    const nodeFetch = require('node-fetch');
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
 
-    nodeFetch(url, { redirect: 'error',
+    fetch(url, { redirect: 'error',
       signal: controller.signal,
       headers: { 'User-Agent': 'Mozilla/5.0 (compatible; NOMAD/1.0; +https://github.com/mauriceboe/NOMAD)' },
     })

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import fetch from 'node-fetch';
+
 import { db } from '../db/database';
 import { authenticate } from '../middleware/auth';
 import { AuthRequest } from '../types';

--- a/server/src/routes/oidc.ts
+++ b/server/src/routes/oidc.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import crypto from 'crypto';
-import fetch from 'node-fetch';
+
 import jwt from 'jsonwebtoken';
 import { db } from '../db/database';
 import { JWT_SECRET } from '../config';

--- a/server/src/routes/places.ts
+++ b/server/src/routes/places.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import fetch from 'node-fetch';
+
 import multer from 'multer';
 import { db, getPlaceWithTags } from '../db/database';
 import { authenticate } from '../middleware/auth';

--- a/server/src/routes/weather.ts
+++ b/server/src/routes/weather.ts
@@ -1,8 +1,11 @@
 import express, { Request, Response } from 'express';
-import fetch from 'node-fetch';
+import dns from 'dns';
 import { authenticate } from '../middleware/auth';
 
 const router = express.Router();
+
+// Force IPv4 to prevent ETIMEDOUT on Docker bridge networks where IPv6 is unroutable.
+dns.setDefaultResultOrder('ipv4first');
 
 interface WeatherResult {
   temp: number;

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -1,5 +1,5 @@
 import nodemailer from 'nodemailer';
-import fetch from 'node-fetch';
+
 import { db } from '../db/database';
 
 // ── Types ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Remove `node-fetch`, use Node 22 native `fetch`

### Problem

`node-fetch@2.7.0` pulls in `whatwg-url@5.0.0` → `tr46@0.0.3`, which imports the built-in `punycode` module deprecated since Node.js 21+. This produces the following warning on every server start:

```
(node:1) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

### Fix

Removed `node-fetch` entirely and switched to Node 22's native global `fetch`. This eliminates the entire dependency chain (`node-fetch`, `whatwg-url`, `tr46`, `webidl-conversions`).

### Changes

- Removed `node-fetch` from `package.json` and `package-lock.json`
- Removed `import fetch from 'node-fetch'` in 6 files: `places.ts`, `oidc.ts`, `auth.ts`, `maps.ts`, `weather.ts`, `notifications.ts`
- Replaced `require('node-fetch')` in `collab.ts` with global `fetch`
- In `weather.ts`, added `dns.setDefaultResultOrder('ipv4first')` to preserve IPv4-first behaviour for Docker bridge networks where IPv6 cannot route to the internet (replaces the approach in PR #180 which used a custom `https.Agent({ family: 4 })`)

### Compatibility audit

All 7 source files use only standard fetch features (`json()`, `text()`, `ok`, `status`, `signal`, `redirect`, `headers`). No node-fetch-specific classes (`Response`, `Request`, `Headers`) or stream handling were in use. `redirect: 'error'` confirmed compatible with native `fetch`.

### Supersedes #180

Using Claude Code - please ignore or use - it's up to you.