### PR TITLE
feat: show holiday name on hover in calendar

### DIFF
--- a/client/src/components/Vacay/VacayMonthCard.tsx
+++ b/client/src/components/Vacay/VacayMonthCard.tsx
@@ -81,6 +81,7 @@ export default function VacayMonthCard({
               return (
                 <div
                   key={di}
+                  title={holiday ? (holiday.label ? `${holiday.label}: ${holiday.localName}` : holiday.localName) : undefined}
                   className="relative flex items-center justify-center cursor-pointer transition-colors"
                   style={{
                     height: 28,


### PR DESCRIPTION
## Summary

- Adds a native `title` tooltip to calendar day cells in `VacayMonthCard`
- Hovering over a public holiday now shows its name (e.g. `Neujahr`)
- If a custom calendar label is configured, it is shown as a prefix (e.g. `Bayern: Neujahr`)

## Test plan

- [ ] Add a holiday calendar in Vacay settings
- [ ] Open the calendar view and hover over a highlighted holiday cell
- [ ] Confirm the tooltip shows the holiday name
- [ ] If a custom label is set, confirm it appears as a prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)