### PR TITLE
fix: badge number partially hidden

### DIFF
--- a/client/src/components/Map/MapView.tsx
+++ b/client/src/components/Map/MapView.tsx
@@ -75,7 +75,8 @@ function createPlaceIcon(place, orderNumbers, isSelected) {
         width:${size}px;height:${size}px;border-radius:50%;
         border:${borderWidth}px solid ${borderColor};
         box-shadow:${shadow};
-        overflow:hidden;background:${bgColor};
+        display:flex;
+        background:${bgColor};
         cursor:pointer;position:relative;
       ">
         <img src="${place.image_url}" width="${size}" height="${size}" style="display:block;border-radius:50%;object-fit:cover;" />


### PR DESCRIPTION
In the trip map, places in the day with a photo taken from google maps, have the badge partially hidden

This small fixes resolve the issue.