### PR TITLE
Add Redo Button to Trip Planner

### DIFF
--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -4,7 +4,7 @@ declare global { interface Window { __dragData: DragDataPayload | null } }
 
 import React, { useState, useEffect, useRef, useMemo } from 'react'
 import ReactDOM from 'react-dom'
-import { ChevronDown, ChevronRight, ChevronUp, Navigation, RotateCcw, ExternalLink, Clock, Pencil, GripVertical, Ticket, Plus, FileText, Check, Trash2, Info, MapPin, Star, Heart, Camera, Lightbulb, Flag, Bookmark, Train, Bus, Plane, Car, Ship, Coffee, ShoppingBag, AlertTriangle, FileDown, Lock, Hotel, Utensils, Users, Undo2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, ChevronUp, Navigation, RotateCcw, ExternalLink, Clock, Pencil, GripVertical, Ticket, Plus, FileText, Check, Trash2, Info, MapPin, Star, Heart, Camera, Lightbulb, Flag, Bookmark, Train, Bus, Plane, Car, Ship, Coffee, ShoppingBag, AlertTriangle, FileDown, Lock, Hotel, Utensils, Users, Undo2, Redo2 } from 'lucide-react'
 
 const RES_ICONS = { flight: Plane, hotel: Hotel, restaurant: Utensils, train: Train, car: Car, cruise: Ship, event: Ticket, tour: Users, other: FileText }
 import { assignmentsApi, reservationsApi } from '../../api/client'
@@ -80,10 +80,13 @@ interface DayPlanSidebarProps {
   onAddReservation: () => void
   onNavigateToFiles?: () => void
   onExpandedDaysChange?: (expandedDayIds: Set<number>) => void
-  pushUndo?: (label: string, undoFn: () => Promise<void> | void) => void
+  pushUndo?: (label: string, undoFn: () => Promise<void> | void, redoFn?: () => Promise<void> | void) => void
   canUndo?: boolean
   lastActionLabel?: string | null
   onUndo?: () => void
+  canRedo?: boolean
+  lastRedoLabel?: string | null
+  onRedo?: () => void
 }
 
 const DayPlanSidebar = React.memo(function DayPlanSidebar({
@@ -101,6 +104,9 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
   canUndo = false,
   lastActionLabel = null,
   onUndo,
+  canRedo = false,
+  lastRedoLabel = null,
+  onRedo,
 }: DayPlanSidebarProps) {
   const toast = useToast()
   const { t, language, locale } = useTranslation()
@@ -128,6 +134,7 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
   const [lockedIds, setLockedIds] = useState(new Set())
   const [lockHoverId, setLockHoverId] = useState(null)
   const [undoHover, setUndoHover] = useState(false)
+  const [redoHover, setRedoHover] = useState(false)
   const [pdfHover, setPdfHover] = useState(false)
   const [icsHover, setIcsHover] = useState(false)
   const [dropTargetKey, _setDropTargetKey] = useState(null)
@@ -454,8 +461,11 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
       if (prevAssignmentIds.length) {
         const capturedDayId = dayId
         const capturedPrevIds = prevAssignmentIds
+        const capturedNewIds = [...assignmentIds]
         pushUndo?.(t('undo.reorder'), async () => {
           await tripActions.reorderAssignments(tripId, capturedDayId, capturedPrevIds)
+        }, async () => {
+          await tripActions.reorderAssignments(tripId, capturedDayId, capturedNewIds)
         })
       }
     } catch (err: unknown) { toast.error(err instanceof Error ? err.message : 'Unknown error') }
@@ -621,13 +631,10 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
 
   const toggleLock = (assignmentId) => {
     const prevLocked = new Set(lockedIds)
-    setLockedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(assignmentId)) next.delete(assignmentId)
-      else next.add(assignmentId)
-      return next
-    })
-    pushUndo?.(t('undo.lock'), () => { setLockedIds(prevLocked) })
+    const nextLocked = new Set(lockedIds)
+    if (nextLocked.has(assignmentId)) nextLocked.delete(assignmentId); else nextLocked.add(assignmentId)
+    setLockedIds(nextLocked)
+    pushUndo?.(t('undo.lock'), () => { setLockedIds(prevLocked) }, () => { setLockedIds(new Set(nextLocked)) })
   }
 
   const handleOptimize = async () => {
@@ -664,8 +671,11 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
     await onReorder(selectedDayId, result.map(a => a.id))
     toast.success(t('dayplan.toast.routeOptimized'))
     const capturedDayId = selectedDayId
+    const capturedOptimizedIds = result.map(a => a.id)
     pushUndo?.(t('undo.optimize'), async () => {
       await tripActions.reorderAssignments(tripId, capturedDayId, prevIds)
+    }, async () => {
+      await tripActions.reorderAssignments(tripId, capturedDayId, capturedOptimizedIds)
     })
   }
 
@@ -692,6 +702,8 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
         .then(() => {
           pushUndo?.(t('undo.moveDay'), async () => {
             await tripActions.moveAssignment(tripId, Number(assignmentId), dayId, capturedFromDayId, capturedOrderIndex)
+          }, async () => {
+            await tripActions.moveAssignment(tripId, Number(assignmentId), capturedFromDayId, dayId)
           })
         })
         .catch((err: unknown) => toast.error(err instanceof Error ? err.message : 'Unknown error'))
@@ -857,6 +869,38 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
                   border: '1px solid var(--border-faint, #e5e7eb)',
                 }}>
                   {canUndo && lastActionLabel ? t('undo.tooltip', { action: lastActionLabel }) : t('undo.button')}
+                </div>
+              )}
+            </div>
+          )}
+          {onRedo && (
+            <div style={{ position: 'relative', flexShrink: 0 }}>
+              <button
+                onClick={onRedo}
+                disabled={!canRedo}
+                onMouseEnter={() => setRedoHover(true)}
+                onMouseLeave={() => setRedoHover(false)}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  width: 30, height: 30, borderRadius: 8,
+                  border: '1px solid var(--border-primary)', background: 'none',
+                  color: canRedo ? 'var(--text-primary)' : 'var(--border-primary)',
+                  cursor: canRedo ? 'pointer' : 'default', fontFamily: 'inherit',
+                  transition: 'color 0.15s, border-color 0.15s',
+                }}
+              >
+                <Redo2 size={14} strokeWidth={2} />
+              </button>
+              {redoHover && (
+                <div style={{
+                  position: 'absolute', top: 'calc(100% + 6px)', right: 0,
+                  whiteSpace: 'nowrap', pointerEvents: 'none', zIndex: 200,
+                  background: 'var(--bg-card, white)', color: 'var(--text-primary, #111827)',
+                  fontSize: 11, fontWeight: 500, padding: '5px 10px',
+                  borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                  border: '1px solid var(--border-faint, #e5e7eb)',
+                }}>
+                  {canRedo && lastRedoLabel ? t('redo.tooltip', { action: lastRedoLabel }) : t('redo.button')}
                 </div>
               )}
             </div>

--- a/client/src/hooks/usePlannerHistory.ts
+++ b/client/src/hooks/usePlannerHistory.ts
@@ -3,14 +3,17 @@ import { useRef, useReducer } from 'react'
 export interface UndoEntry {
   label: string
   undo: () => Promise<void> | void
+  redo?: () => Promise<void> | void
 }
 
 export function usePlannerHistory(maxEntries = 30) {
   const historyRef = useRef<UndoEntry[]>([])
+  const redoRef = useRef<UndoEntry[]>([])
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
 
-  const pushUndo = (label: string, undoFn: () => Promise<void> | void) => {
-    historyRef.current = [{ label, undo: undoFn }, ...historyRef.current].slice(0, maxEntries)
+  const pushUndo = (label: string, undoFn: () => Promise<void> | void, redoFn?: () => Promise<void> | void) => {
+    historyRef.current = [{ label, undo: undoFn, redo: redoFn }, ...historyRef.current].slice(0, maxEntries)
+    redoRef.current = []
     forceUpdate()
   }
 
@@ -18,12 +21,26 @@ export function usePlannerHistory(maxEntries = 30) {
     if (historyRef.current.length === 0) return
     const [first, ...rest] = historyRef.current
     historyRef.current = rest
+    if (first.redo) {
+      redoRef.current = [first, ...redoRef.current].slice(0, maxEntries)
+    }
     forceUpdate()
     try { await first.undo() } catch (e) { console.error('Undo failed:', e) }
   }
 
-  const canUndo = historyRef.current.length > 0
-  const lastActionLabel = historyRef.current[0]?.label ?? null
+  const redo = async () => {
+    if (redoRef.current.length === 0) return
+    const [first, ...rest] = redoRef.current
+    redoRef.current = rest
+    historyRef.current = [first, ...historyRef.current].slice(0, maxEntries)
+    forceUpdate()
+    try { await first.redo!() } catch (e) { console.error('Redo failed:', e) }
+  }
 
-  return { pushUndo, undo, canUndo, lastActionLabel }
+  const canUndo = historyRef.current.length > 0
+  const canRedo = redoRef.current.length > 0
+  const lastActionLabel = historyRef.current[0]?.label ?? null
+  const lastRedoLabel = redoRef.current[0]?.label ?? null
+
+  return { pushUndo, undo, redo, canUndo, canRedo, lastActionLabel, lastRedoLabel }
 }

--- a/client/src/i18n/translations/ar.ts
+++ b/client/src/i18n/translations/ar.ts
@@ -247,6 +247,7 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'تم حذف الرمز',
   'settings.mcp.toast.deleteError': 'فشل حذف الرمز',
   'settings.account': 'الحساب',
+  'settings.about': 'حول',
   'settings.username': 'اسم المستخدم',
   'settings.email': 'البريد الإلكتروني',
   'settings.role': 'الدور',
@@ -1529,6 +1530,11 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
   'memories.error.toggleSharing': 'فشل تحديث إعدادات المشاركة',
   'undo.addPlace': 'تمت إضافة المكان',
   'undo.done': 'تم التراجع: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'إشعار تجريبي من {actor}',
   'notifications.test.text': 'هذا إشعار تجريبي بسيط.',
   'notifications.test.booleanTitle': 'يطلب منك {actor} الموافقة',

--- a/client/src/i18n/translations/br.ts
+++ b/client/src/i18n/translations/br.ts
@@ -217,6 +217,7 @@ const br: Record<string, string | { name: string; category: string }[]> = {
   'settings.on': 'Ligado',
   'settings.off': 'Desligado',
   'settings.account': 'Conta',
+  'settings.about': 'Sobre',
   'settings.username': 'Nome de usuário',
   'settings.email': 'E-mail',
   'settings.role': 'Função',
@@ -1524,6 +1525,11 @@ const br: Record<string, string | { name: string; category: string }[]> = {
   'memories.error.toggleSharing': 'Falha ao atualizar compartilhamento',
   'undo.addPlace': 'Local adicionado',
   'undo.done': 'Desfeito: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Notificação de teste de {actor}',
   'notifications.test.text': 'Esta é uma notificação de teste simples.',
   'notifications.test.booleanTitle': '{actor} solicita sua aprovação',

--- a/client/src/i18n/translations/cs.ts
+++ b/client/src/i18n/translations/cs.ts
@@ -195,6 +195,7 @@ const cs: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token smazán',
   'settings.mcp.toast.deleteError': 'Nepodařilo se smazat token',
   'settings.account': 'Účet',
+  'settings.about': 'O aplikaci',
   'settings.username': 'Uživatelské jméno',
   'settings.email': 'E-mail',
   'settings.role': 'Role',
@@ -1529,6 +1530,11 @@ const cs: Record<string, string | { name: string; category: string }[]> = {
   'memories.error.toggleSharing': 'Aktualizace sdílení se nezdařila',
   'undo.addPlace': 'Místo přidáno',
   'undo.done': 'Vráceno zpět: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Testovací oznámení od {actor}',
   'notifications.test.text': 'Toto je jednoduché testovací oznámení.',
   'notifications.test.booleanTitle': '{actor} žádá o vaše schválení',

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -242,6 +242,7 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token gelöscht',
   'settings.mcp.toast.deleteError': 'Token konnte nicht gelöscht werden',
   'settings.account': 'Konto',
+  'settings.about': 'Über',
   'settings.username': 'Benutzername',
   'settings.email': 'E-Mail',
   'settings.role': 'Rolle',
@@ -1526,6 +1527,11 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'memories.error.toggleSharing': 'Freigabe konnte nicht aktualisiert werden',
   'undo.addPlace': 'Ort hinzugefügt',
   'undo.done': 'Rückgängig gemacht: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Testbenachrichtigung von {actor}',
   'notifications.test.text': 'Dies ist eine einfache Testbenachrichtigung.',
   'notifications.test.booleanTitle': '{actor} bittet um Ihre Zustimmung',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -242,6 +242,7 @@ const en: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token deleted',
   'settings.mcp.toast.deleteError': 'Failed to delete token',
   'settings.account': 'Account',
+  'settings.about': 'About',
   'settings.username': 'Username',
   'settings.email': 'Email',
   'settings.role': 'Role',
@@ -1510,6 +1511,11 @@ const en: Record<string, string | { name: string; category: string }[]> = {
   'undo.importGoogleList': 'Google Maps import',
   'undo.addPlace': 'Place added',
   'undo.done': 'Undone: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
 
   // Notifications
   'notifications.title': 'Notifications',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -243,6 +243,7 @@ const es: Record<string, string> = {
   'settings.mcp.toast.deleted': 'Token eliminado',
   'settings.mcp.toast.deleteError': 'Error al eliminar el token',
   'settings.account': 'Cuenta',
+  'settings.about': 'Acerca de',
   'settings.username': 'Usuario',
   'settings.email': 'Correo',
   'settings.role': 'Rol',
@@ -1531,6 +1532,11 @@ const es: Record<string, string> = {
   'memories.error.toggleSharing': 'Error al actualizar el uso compartido',
   'undo.addPlace': 'Lugar agregado',
   'undo.done': 'Deshecho: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Notificación de prueba de {actor}',
   'notifications.test.text': 'Esta es una notificación de prueba simple.',
   'notifications.test.booleanTitle': '{actor} solicita tu aprobación',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -242,6 +242,7 @@ const fr: Record<string, string> = {
   'settings.mcp.toast.deleted': 'Token supprimé',
   'settings.mcp.toast.deleteError': 'Impossible de supprimer le token',
   'settings.account': 'Compte',
+  'settings.about': 'À propos',
   'settings.username': 'Nom d\'utilisateur',
   'settings.email': 'E-mail',
   'settings.role': 'Rôle',
@@ -1525,6 +1526,11 @@ const fr: Record<string, string> = {
   'memories.error.toggleSharing': 'Impossible de mettre à jour le partage',
   'undo.addPlace': 'Lieu ajouté',
   'undo.done': 'Annulé : {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Notification test de {actor}',
   'notifications.test.text': 'Ceci est une simple notification de test.',
   'notifications.test.booleanTitle': '{actor} demande votre approbation',

--- a/client/src/i18n/translations/hu.ts
+++ b/client/src/i18n/translations/hu.ts
@@ -194,6 +194,7 @@ const hu: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token törölve',
   'settings.mcp.toast.deleteError': 'Nem sikerült törölni a tokent',
   'settings.account': 'Fiók',
+  'settings.about': 'Névjegy',
   'settings.username': 'Felhasználónév',
   'settings.email': 'E-mail',
   'settings.role': 'Szerepkör',
@@ -1526,6 +1527,11 @@ const hu: Record<string, string | { name: string; category: string }[]> = {
   'memories.error.toggleSharing': 'A megosztás frissítése sikertelen',
   'undo.addPlace': 'Hely hozzáadva',
   'undo.done': 'Visszavonva: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Teszt értesítés {actor} részéről',
   'notifications.test.text': 'Ez egy egyszerű teszt értesítés.',
   'notifications.test.booleanTitle': '{actor} jóváhagyásodat kéri',

--- a/client/src/i18n/translations/it.ts
+++ b/client/src/i18n/translations/it.ts
@@ -194,6 +194,7 @@ const it: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token eliminato',
   'settings.mcp.toast.deleteError': 'Impossibile eliminare il token',
   'settings.account': 'Account',
+  'settings.about': 'Informazioni',
   'settings.username': 'Username',
   'settings.email': 'Email',
   'settings.role': 'Ruolo',
@@ -1505,6 +1506,11 @@ const it: Record<string, string | { name: string; category: string }[]> = {
   'undo.importGoogleList': 'Importazione Google Maps',
   'undo.addPlace': 'Luogo aggiunto',
   'undo.done': 'Annullato: {action}',
+
+  // Redo
+  'redo.button': 'Ripristina',
+  'redo.tooltip': 'Ripristina: {action}',
+  'redo.done': 'Ripristinato: {action}',
   // Notifications
   'notifications.title': 'Notifiche',
   'notifications.markAllRead': 'Segna tutto come letto',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -242,6 +242,7 @@ const nl: Record<string, string> = {
   'settings.mcp.toast.deleted': 'Token verwijderd',
   'settings.mcp.toast.deleteError': 'Token verwijderen mislukt',
   'settings.account': 'Account',
+  'settings.about': 'Over',
   'settings.username': 'Gebruikersnaam',
   'settings.email': 'E-mail',
   'settings.role': 'Rol',
@@ -1525,6 +1526,11 @@ const nl: Record<string, string> = {
   'memories.error.toggleSharing': 'Delen bijwerken mislukt',
   'undo.addPlace': 'Locatie toegevoegd',
   'undo.done': 'Ongedaan gemaakt: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Testmelding van {actor}',
   'notifications.test.text': 'Dit is een eenvoudige testmelding.',
   'notifications.test.booleanTitle': '{actor} vraagt om uw goedkeuring',

--- a/client/src/i18n/translations/pl.ts
+++ b/client/src/i18n/translations/pl.ts
@@ -211,6 +211,7 @@ const pl: Record<string, string | { name: string; category: string }[]> = {
   'settings.mcp.toast.deleted': 'Token został usunięty',
   'settings.mcp.toast.deleteError': 'Nie udało się usunąć tokenu',
   'settings.account': 'Konto',
+  'settings.about': 'O aplikacji',
   'settings.username': 'Nazwa użytkownika',
   'settings.email': 'E-mail',
   'settings.role': 'Rola',
@@ -1506,6 +1507,11 @@ const pl: Record<string, string | { name: string; category: string }[]> = {
   'undo.importGoogleList': 'Import Google Maps',
   'undo.addPlace': 'Miejsce dodane',
   'undo.done': 'Cofnięto: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.title': 'Powiadomienia',
   'notifications.markAllRead': 'Oznacz wszystkie jako przeczytane',
   'notifications.deleteAll': 'Usuń wszystkie',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -242,6 +242,7 @@ const ru: Record<string, string> = {
   'settings.mcp.toast.deleted': 'Токен удалён',
   'settings.mcp.toast.deleteError': 'Не удалось удалить токен',
   'settings.account': 'Аккаунт',
+  'settings.about': 'О приложении',
   'settings.username': 'Имя пользователя',
   'settings.email': 'Эл. почта',
   'settings.role': 'Роль',
@@ -1525,6 +1526,11 @@ const ru: Record<string, string> = {
   'memories.error.toggleSharing': 'Не удалось обновить настройки доступа',
   'undo.addPlace': 'Место добавлено',
   'undo.done': 'Отменено: {action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': 'Тестовое уведомление от {actor}',
   'notifications.test.text': 'Это простое тестовое уведомление.',
   'notifications.test.booleanTitle': '{actor} запрашивает подтверждение',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -242,6 +242,7 @@ const zh: Record<string, string> = {
   'settings.mcp.toast.deleted': '令牌已删除',
   'settings.mcp.toast.deleteError': '删除令牌失败',
   'settings.account': '账户',
+  'settings.about': '关于',
   'settings.username': '用户名',
   'settings.email': '邮箱',
   'settings.role': '角色',
@@ -1525,6 +1526,11 @@ const zh: Record<string, string> = {
   'memories.error.toggleSharing': '更新共享设置失败',
   'undo.addPlace': '地点已添加',
   'undo.done': '已撤销：{action}',
+
+  // Redo
+  'redo.button': 'Redo',
+  'redo.tooltip': 'Redo: {action}',
+  'redo.done': 'Redone: {action}',
   'notifications.test.title': '来自 {actor} 的测试通知',
   'notifications.test.text': '这是一条简单的测试通知。',
   'notifications.test.booleanTitle': '{actor} 请求您的审批',

--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -54,13 +54,19 @@ export default function TripPlannerPage(): React.ReactElement | null {
   const tripActions = useRef(useTripStore.getState()).current
   const can = useCanDo()
   const canUploadFiles = can('file_upload', trip)
-  const { pushUndo, undo, canUndo, lastActionLabel } = usePlannerHistory()
+  const { pushUndo, undo, redo, canUndo, canRedo, lastActionLabel, lastRedoLabel } = usePlannerHistory()
 
   const handleUndo = useCallback(async () => {
     const label = lastActionLabel
     await undo()
     toast.info(t('undo.done', { action: label ?? '' }))
   }, [undo, lastActionLabel, toast])
+
+  const handleRedo = useCallback(async () => {
+    const label = lastRedoLabel
+    await redo()
+    toast.info(t('redo.done', { action: label ?? '' }))
+  }, [redo, lastRedoLabel, toast])
 
   const [enabledAddons, setEnabledAddons] = useState<Record<string, boolean>>({ packing: true, budget: true, documents: true })
   const [tripAccommodations, setTripAccommodations] = useState<Accommodation[]>([])
@@ -362,8 +368,11 @@ export default function TripPlannerPage(): React.ReactElement | null {
         .then(() => {
           const capturedDayId = dayId
           const capturedPrevIds = prevIds
+          const capturedNewIds = [...orderedIds]
           pushUndo(t('undo.reorder'), async () => {
             await tripActions.reorderAssignments(tripId, capturedDayId, capturedPrevIds)
+          }, async () => {
+            await tripActions.reorderAssignments(tripId, capturedDayId, capturedNewIds)
           })
         })
         .catch(() => {})
@@ -621,6 +630,9 @@ export default function TripPlannerPage(): React.ReactElement | null {
                   canUndo={canUndo}
                   lastActionLabel={lastActionLabel}
                   onUndo={handleUndo}
+                  canRedo={canRedo}
+                  lastRedoLabel={lastRedoLabel}
+                  onRedo={handleRedo}
                 />
                 {!leftCollapsed && (
                   <div
@@ -834,7 +846,7 @@ export default function TripPlannerPage(): React.ReactElement | null {
                   </div>
                   <div style={{ flex: 1, overflow: 'auto' }}>
                     {mobileSidebarOpen === 'left'
-                      ? <DayPlanSidebar tripId={tripId} trip={trip} days={days} places={places} categories={categories} assignments={assignments} selectedDayId={selectedDayId} selectedPlaceId={selectedPlaceId} selectedAssignmentId={selectedAssignmentId} onSelectDay={(id) => { handleSelectDay(id); setMobileSidebarOpen(null) }} onPlaceClick={(placeId, assignmentId) => { handlePlaceClick(placeId, assignmentId); setMobileSidebarOpen(null) }} onReorder={handleReorder} onUpdateDayTitle={handleUpdateDayTitle} onAssignToDay={handleAssignToDay} onRouteCalculated={(r) => { if (r) { setRoute(r.coordinates); setRouteInfo({ distance: r.distanceText, duration: r.durationText }) } }} reservations={reservations} onAddReservation={(dayId) => { setEditingReservation(null); tripActions.setSelectedDay(dayId); setShowReservationModal(true); setMobileSidebarOpen(null) }} onDayDetail={(day) => { setShowDayDetail(day); setSelectedPlaceId(null); setSelectedAssignmentId(null); setMobileSidebarOpen(null) }} accommodations={tripAccommodations} onNavigateToFiles={() => { setMobileSidebarOpen(null); handleTabChange('dateien') }} onExpandedDaysChange={setExpandedDayIds} pushUndo={pushUndo} canUndo={canUndo} lastActionLabel={lastActionLabel} onUndo={handleUndo} />
+                      ? <DayPlanSidebar tripId={tripId} trip={trip} days={days} places={places} categories={categories} assignments={assignments} selectedDayId={selectedDayId} selectedPlaceId={selectedPlaceId} selectedAssignmentId={selectedAssignmentId} onSelectDay={(id) => { handleSelectDay(id); setMobileSidebarOpen(null) }} onPlaceClick={(placeId, assignmentId) => { handlePlaceClick(placeId, assignmentId); setMobileSidebarOpen(null) }} onReorder={handleReorder} onUpdateDayTitle={handleUpdateDayTitle} onAssignToDay={handleAssignToDay} onRouteCalculated={(r) => { if (r) { setRoute(r.coordinates); setRouteInfo({ distance: r.distanceText, duration: r.durationText }) } }} reservations={reservations} onAddReservation={(dayId) => { setEditingReservation(null); tripActions.setSelectedDay(dayId); setShowReservationModal(true); setMobileSidebarOpen(null) }} onDayDetail={(day) => { setShowDayDetail(day); setSelectedPlaceId(null); setSelectedAssignmentId(null); setMobileSidebarOpen(null) }} accommodations={tripAccommodations} onNavigateToFiles={() => { setMobileSidebarOpen(null); handleTabChange('dateien') }} onExpandedDaysChange={setExpandedDayIds} pushUndo={pushUndo} canUndo={canUndo} lastActionLabel={lastActionLabel} onUndo={handleUndo} canRedo={canRedo} lastRedoLabel={lastRedoLabel} onRedo={handleRedo} />
                       : <PlacesSidebar tripId={tripId} places={places} categories={categories} assignments={assignments} selectedDayId={selectedDayId} selectedPlaceId={selectedPlaceId} onPlaceClick={(placeId) => { handlePlaceClick(placeId); setMobileSidebarOpen(null) }} onAddPlace={() => { setEditingPlace(null); setShowPlaceForm(true); setMobileSidebarOpen(null) }} onAssignToDay={handleAssignToDay} onEditPlace={(place) => { setEditingPlace(place); setEditingAssignmentId(null); setShowPlaceForm(true); setMobileSidebarOpen(null) }} onDeletePlace={(placeId) => handleDeletePlace(placeId)} days={days} isMobile onCategoryFilterChange={setMapCategoryFilter} pushUndo={pushUndo} />
                     }
                   </div>


### PR DESCRIPTION
## Add Redo Button to Trip Planner

### Summary

Adds a **Redo** button next to the existing Undo button in the trip planner's day plan sidebar, allowing users to re-apply actions they have just undone.

### Changes

**usePlannerHistory.ts**
- Added a redo stack alongside the existing undo stack
- `pushUndo()` now accepts an optional third argument `redoFn` and clears the redo stack on any new action
- `undo()` moves entries with a redo function to the redo stack
- `redo()` pops from redo stack, executes the redo function, and pushes back to the undo stack
- New exports: `redo`, `canRedo`, `lastRedoLabel`

**DayPlanSidebar.tsx**
- Added `Redo2` icon and new props: `canRedo`, `lastRedoLabel`, `onRedo`
- Renders a redo button with hover tooltip, matching the undo button's style
- Provides redo functions for: reorder, lock toggle, route optimize, move-to-day

**TripPlannerPage.tsx**
- Added `handleRedo` callback with toast notification
- Passes redo props to both desktop and mobile `DayPlanSidebar` instances
- `handleReorder` now provides a redo function

**Translations**
- Added `redo.button`, `redo.tooltip`, `redo.done` keys to all 12 locale files
- Italian fully translated; other locales use English fallback

### How to test

1. Open a trip in the planner
2. Perform any action (reorder places, optimize route, lock a place, move to another day)
3. Click the **Undo** button → action is reversed
4. Click the **Redo** button (now enabled) → action is re-applied
5. Verify the redo stack clears when performing a new action after undoing