### PR TITLE
fix(helm): include all env variables from values

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -5,17 +5,6 @@ metadata:
   labels:
     app: {{ include "trek.name" . }}
 data:
-  NODE_ENV: {{ .Values.env.NODE_ENV | quote }}
-  PORT: {{ .Values.env.PORT | quote }}
-  {{- if .Values.env.ALLOWED_ORIGINS }}
-  ALLOWED_ORIGINS: {{ .Values.env.ALLOWED_ORIGINS | quote }}
-  {{- end }}
-  {{- if .Values.env.ALLOW_INTERNAL_NETWORK }}
-  ALLOW_INTERNAL_NETWORK: {{ .Values.env.ALLOW_INTERNAL_NETWORK | quote }}
-  {{- end }}
-  {{- if .Values.env.COOKIE_SECURE }}
-  COOKIE_SECURE: {{ .Values.env.COOKIE_SECURE | quote }}
-  {{- end }}
-  {{- if .Values.env.OIDC_DISCOVERY_URL }}
-  OIDC_DISCOVERY_URL: {{ .Values.env.OIDC_DISCOVERY_URL | quote }}
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,17 +15,30 @@ service:
 env:
   NODE_ENV: production
   PORT: 3000
+  TZ: UTC
+  LOG_LEVEL: info
+  # APP_URL: ""
   # ALLOWED_ORIGINS: ""
   # NOTE: If using ingress, ensure env.ALLOWED_ORIGINS matches the domains in ingress.hosts for proper CORS configuration.
+  # FORCE_HTTPS: "false"
   # ALLOW_INTERNAL_NETWORK: "false"
   # Set to "true" if Immich or other integrated services are hosted on a private/RFC-1918 network address.
   # Loopback (127.x) and link-local/metadata addresses (169.254.x) are always blocked.
   # COOKIE_SECURE: "true"
   # Set to "false" to allow session cookies over plain HTTP (e.g. no ingress TLS). Not recommended for production.
+  # TRUST_PROXY: "1"
+  # OIDC_ISSUER: ""
+  # OIDC_CLIENT_ID: ""
+  # OIDC_CLIENT_SECRET: ""
+  # OIDC_DISPLAY_NAME: "SSO"
+  # OIDC_ONLY: "false"
+  # OIDC_ADMIN_CLAIM: ""
+  # OIDC_ADMIN_VALUE: ""
   # OIDC_DISCOVERY_URL: ""
   # Override the OIDC discovery endpoint for providers with non-standard paths (e.g. Authentik).
   # OIDC_SCOPE: "openid email profile groups"
   # Space-separated OIDC scopes to request. Must include scopes for any claim used by OIDC_ADMIN_CLAIM.
+  # DEMO_MODE: "false"
 
 
 # Secret environment variables stored in a Kubernetes Secret.


### PR DESCRIPTION
Fixes #362 by including all env variables specified in `values.yaml`. 