### PR TITLE
chore(helm): add config/secret checksum to deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
       app: {{ include "trek.name" . }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: {{ include "trek.name" . }}
     spec:


### PR DESCRIPTION
This PR adds a config and secret checksum to pod template annotations of the spec of the deployment of the Helm Chart.

This is useful in cases where GitOps is used (e.g., ArgoCD), because Kubernetes does not automatically redeploy pods when underlying resources (here: configmap, secrets) are changed. 