### PR TITLE
fix(files): prepend /uploads/avatars/ to avatar URL in documents tab

### DIFF
--- a/server/src/services/fileService.ts
+++ b/server/src/services/fileService.ts
@@ -42,6 +42,7 @@ export function formatFile(file: TripFile & { trip_id?: number }) {
   return {
     ...file,
     url: `/api/trips/${tripId}/files/${file.id}/download`,
+    uploaded_by_avatar: file.uploaded_by_avatar ? `/uploads/avatars/${file.uploaded_by_avatar}` : null,
   };
 }
 


### PR DESCRIPTION
Raw avatar filename was passed through formatFile without being transformed into a full URL path, causing the browser to resolve it relative to the current /trips/... page. Closes #417.