### PR TITLE
feat(mcp): add todo list tools and resource

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -93,6 +93,7 @@ making changes.
 | Accommodations    | `trek://trips/{tripId}/accommodations`     | Hotels/rentals with check-in/out details                  |
 | Members           | `trek://trips/{tripId}/members`            | Owner and collaborators                                   |
 | Collab Notes      | `trek://trips/{tripId}/collab-notes`       | Shared collaborative notes                                |
+| Todos             | `trek://trips/{tripId}/todos`              | To-do checklist items                                     |
 | Categories        | `trek://categories`                        | Available place categories (for use when creating places) |
 | Bucket List       | `trek://bucket-list`                       | Your personal travel bucket list                          |
 | Visited Countries | `trek://visited-countries`                 | Countries marked as visited in Atlas                      |
@@ -101,14 +102,14 @@ making changes.
 
 ## Tools (read-write)
 
-TREK exposes **34 tools** organized by feature area. Use `get_trip_summary` as a starting point — it returns everything
+TREK exposes **39 tools** organized by feature area. Use `get_trip_summary` as a starting point — it returns everything
 about a trip in a single call.
 
 ### Trip Summary
 
 | Tool               | Description                                                                                                                                                                                              |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `get_trip_summary` | Full denormalized snapshot of a trip: metadata, members, days with assignments and notes, accommodations, budget totals, packing stats, reservations, and collab notes. Use this as your context loader. |
+| `get_trip_summary` | Full denormalized snapshot of a trip: metadata, members, days with assignments and notes, accommodations, budget totals, packing stats, todo stats, reservations, and collab notes. Use this as your context loader. |
 
 ### Trips
 
@@ -162,6 +163,16 @@ about a trip in a single call.
 | `update_packing_item` | Rename an item or change its category.                       |
 | `toggle_packing_item` | Check or uncheck a packing item.                             |
 | `delete_packing_item` | Remove a packing item.                                       |
+
+### Todos
+
+| Tool                 | Description                                                                           |
+|----------------------|---------------------------------------------------------------------------------------|
+| `create_todo_item`   | Add a to-do item with name, optional category, due date, description, and priority.   |
+| `update_todo_item`   | Update a to-do item's name, category, due date, description, or priority.             |
+| `toggle_todo_item`   | Check or uncheck a to-do item.                                                        |
+| `delete_todo_item`   | Remove a to-do item from a trip.                                                      |
+| `reorder_todo_items` | Reorder to-do items by providing item IDs in the desired order.                       |
 
 ### Day Notes
 

--- a/server/src/mcp/resources.ts
+++ b/server/src/mcp/resources.ts
@@ -10,6 +10,7 @@ import { listNotes as listDayNotes } from '../services/dayNoteService';
 import { listNotes as listCollabNotes } from '../services/collabService';
 import { listCategories } from '../services/categoryService';
 import { listBucketList, listVisitedCountries } from '../services/atlasService';
+import { listItems as listTodoItems } from '../services/todoService';
 
 function parseId(value: string | string[]): number | null {
   const n = Number(Array.isArray(value) ? value[0] : value);
@@ -179,6 +180,19 @@ export function registerResources(server: McpServer, userId: number): void {
       if (id === null || !canAccessTrip(id, userId)) return accessDenied(uri.href);
       const notes = listCollabNotes(id);
       return jsonContent(uri.href, notes);
+    }
+  );
+
+  // Todo items for a trip
+  server.registerResource(
+    'trip-todos',
+    new ResourceTemplate('trek://trips/{tripId}/todos', { list: undefined }),
+    { description: 'To-do checklist items for a trip' },
+    async (uri, { tripId }) => {
+      const id = parseId(tripId);
+      if (id === null || !canAccessTrip(id, userId)) return accessDenied(uri.href);
+      const items = listTodoItems(id);
+      return jsonContent(uri.href, items);
     }
   );
 

--- a/server/src/mcp/tools.ts
+++ b/server/src/mcp/tools.ts
@@ -23,6 +23,11 @@ import {
   markCountryVisited, unmarkCountryVisited, createBucketItem, deleteBucketItem,
 } from '../services/atlasService';
 import { searchPlaces } from '../services/mapsService';
+import {
+  listItems as listTodoItems, createItem as createTodoItem,
+  updateItem as updateTodoItem, deleteItem as deleteTodoItem,
+  reorderItems as reorderTodoItems,
+} from '../services/todoService';
 
 const MAX_MCP_TRIP_DAYS = 90;
 
@@ -826,6 +831,124 @@ export function registerTools(server: McpServer, userId: number): void {
       if (!deleted) return { content: [{ type: 'text' as const, text: 'Note not found.' }], isError: true };
       broadcast(tripId, 'collab:note:deleted', { noteId });
       return ok({ success: true });
+    }
+  );
+
+  // --- TODO ITEMS ---
+
+  server.registerTool(
+    'create_todo_item',
+    {
+      description: 'Add a to-do item to a trip\'s checklist.',
+      inputSchema: {
+        tripId: z.number().int().positive(),
+        name: z.string().min(1).max(200),
+        category: z.string().max(100).optional().describe('Category (e.g. "Before Trip", "On Arrival")'),
+        due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('Due date (YYYY-MM-DD)'),
+        description: z.string().max(2000).optional().describe('Longer description or details'),
+        priority: z.number().int().min(0).max(3).optional().describe('Priority: 0 = none, 1 = low, 2 = medium, 3 = high'),
+      },
+    },
+    async ({ tripId, name, category, due_date, description, priority }) => {
+      if (isDemoUser(userId)) return demoDenied();
+      if (!canAccessTrip(tripId, userId)) return noAccess();
+      if (due_date) {
+        const d = new Date(due_date + 'T00:00:00Z');
+        if (isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== due_date)
+          return { content: [{ type: 'text' as const, text: 'due_date is not a valid calendar date.' }], isError: true };
+      }
+      const item = createTodoItem(tripId, { name, category, due_date, description, priority });
+      broadcast(tripId, 'todo:created', { item });
+      return ok({ item });
+    }
+  );
+
+  server.registerTool(
+    'update_todo_item',
+    {
+      description: 'Update an existing to-do item in a trip.',
+      inputSchema: {
+        tripId: z.number().int().positive(),
+        itemId: z.number().int().positive(),
+        name: z.string().min(1).max(200).optional(),
+        category: z.string().max(100).optional(),
+        due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional().describe('Due date (YYYY-MM-DD), or null to clear'),
+        description: z.string().max(2000).nullable().optional().describe('Description, or null to clear'),
+        priority: z.number().int().min(0).max(3).nullable().optional().describe('Priority: 0 = none, 1 = low, 2 = medium, 3 = high'),
+      },
+    },
+    async ({ tripId, itemId, name, category, due_date, description, priority }) => {
+      if (isDemoUser(userId)) return demoDenied();
+      if (!canAccessTrip(tripId, userId)) return noAccess();
+      if (due_date) {
+        const d = new Date(due_date + 'T00:00:00Z');
+        if (isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== due_date)
+          return { content: [{ type: 'text' as const, text: 'due_date is not a valid calendar date.' }], isError: true };
+      }
+      const bodyKeys = ['name', 'category', 'due_date', 'description', 'priority'].filter(
+        k => ({ name, category, due_date, description, priority })[k] !== undefined
+      );
+      const item = updateTodoItem(tripId, itemId, { name, category, due_date, description, priority }, bodyKeys);
+      if (!item) return { content: [{ type: 'text' as const, text: 'To-do item not found.' }], isError: true };
+      broadcast(tripId, 'todo:updated', { item });
+      return ok({ item });
+    }
+  );
+
+  server.registerTool(
+    'toggle_todo_item',
+    {
+      description: 'Check or uncheck a to-do item.',
+      inputSchema: {
+        tripId: z.number().int().positive(),
+        itemId: z.number().int().positive(),
+        checked: z.boolean(),
+      },
+    },
+    async ({ tripId, itemId, checked }) => {
+      if (isDemoUser(userId)) return demoDenied();
+      if (!canAccessTrip(tripId, userId)) return noAccess();
+      const item = updateTodoItem(tripId, itemId, { checked: checked ? 1 : 0 }, ['checked']);
+      if (!item) return { content: [{ type: 'text' as const, text: 'To-do item not found.' }], isError: true };
+      broadcast(tripId, 'todo:updated', { item });
+      return ok({ item });
+    }
+  );
+
+  server.registerTool(
+    'delete_todo_item',
+    {
+      description: 'Delete a to-do item from a trip.',
+      inputSchema: {
+        tripId: z.number().int().positive(),
+        itemId: z.number().int().positive(),
+      },
+    },
+    async ({ tripId, itemId }) => {
+      if (isDemoUser(userId)) return demoDenied();
+      if (!canAccessTrip(tripId, userId)) return noAccess();
+      const deleted = deleteTodoItem(tripId, itemId);
+      if (!deleted) return { content: [{ type: 'text' as const, text: 'To-do item not found.' }], isError: true };
+      broadcast(tripId, 'todo:deleted', { itemId });
+      return ok({ success: true });
+    }
+  );
+
+  server.registerTool(
+    'reorder_todo_items',
+    {
+      description: 'Reorder to-do items in a trip by providing item IDs in the desired order.',
+      inputSchema: {
+        tripId: z.number().int().positive(),
+        itemIds: z.array(z.number().int().positive()).min(1).max(500).describe('Item IDs in desired display order'),
+      },
+    },
+    async ({ tripId, itemIds }) => {
+      if (isDemoUser(userId)) return demoDenied();
+      if (!canAccessTrip(tripId, userId)) return noAccess();
+      reorderTodoItems(tripId, itemIds);
+      broadcast(tripId, 'todo:reordered', { itemIds });
+      return ok({ success: true, order: itemIds });
     }
   );
 

--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -7,6 +7,7 @@ import { listBudgetItems } from './budgetService';
 import { listItems as listPackingItems } from './packingService';
 import { listReservations } from './reservationService';
 import { listNotes as listCollabNotes } from './collabService';
+import { listItems as listTodoItems } from './todoService';
 
 export const MS_PER_DAY = 86400000;
 export const MAX_TRIP_DAYS = 365;
@@ -462,6 +463,12 @@ export function getTripSummary(tripId: number) {
   const reservations = listReservations(tripId);
   const collab_notes = listCollabNotes(tripId);
 
+  const todoItems = listTodoItems(tripId);
+  const todos = {
+    total: todoItems.length,
+    checked: (todoItems as { checked: number }[]).filter(i => i.checked).length,
+  };
+
   return {
     trip,
     members: { owner, collaborators: members },
@@ -471,6 +478,7 @@ export function getTripSummary(tripId: number) {
     packing,
     reservations,
     collab_notes,
+    todos,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds 5 MCP tools for the todo list feature: `create_todo_item`, `update_todo_item`, `toggle_todo_item`, `delete_todo_item`, `reorder_todo_items`
- Adds `trek://trips/{tripId}/todos` MCP resource for read-only access to todo items
- Includes todo stats (total/checked) in `get_trip_summary` response

## Details

All tools follow the same structure as the existing packing list MCP tools:
- `demoDenied` / `canAccessTrip` guards
- Zod input validation
- WebSocket broadcast on mutations
- Consistent error responses via `ok()` / `noAccess()`

The `update_todo_item` tool supports nullable fields (`due_date`, `description`, `priority`) to allow clearing values, matching the pattern used elsewhere (e.g. day note `time`).

## Files Changed

| File | Change |
|------|--------|
| `server/src/mcp/tools.ts` | 5 new tool registrations + todoService import |
| `server/src/mcp/resources.ts` | 1 new resource registration + todoService import |
| `server/src/services/tripService.ts` | Todo stats added to `getTripSummary` |
| `MCP.md` | Docs updated: resource table, tool count (34→39), new Todos section |