### PR TITLE
DRAFT: MCP Token query parameter support

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -56,6 +56,14 @@ The Settings page shows a ready-to-copy client configuration snippet. For **Clau
 
 > The path to `npx` may need to be adjusted for your system (e.g. `C:\PROGRA~1\nodejs\npx.cmd` on Windows).
 
+If your MCP client cannot set custom headers, you can pass the token as a URL query parameter instead:
+
+```
+https://your-trek-instance.com/mcp?token=trek_your_token_here
+```
+
+> **Security note:** Query parameters may appear in server logs. Prefer the `Authorization` header when your client supports it.
+
 ---
 
 ## Limitations & Important Notes

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -71,7 +71,8 @@ sessionSweepInterval.unref();
 function verifyToken(req: Request): User | null {
   // Accept token from Authorization header or ?token= query parameter
   const authHeader = req.headers['authorization'];
-  const rawToken = (authHeader && authHeader.split(' ')[1]) || (req.query.token as string | undefined);
+  const queryToken = Array.isArray(req.query.token) ? req.query.token[0] : (req.query.token as string | undefined);
+  const rawToken = (authHeader && authHeader.split(' ')[1]) || queryToken;
   if (!rawToken) return null;
 
   // Long-lived MCP API token (trek_...)

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -68,17 +68,19 @@ const sessionSweepInterval = setInterval(() => {
 // Prevent the interval from keeping the process alive if nothing else is running
 sessionSweepInterval.unref();
 
-function verifyToken(authHeader: string | undefined): User | null {
-  const token = authHeader && authHeader.split(' ')[1];
-  if (!token) return null;
+function verifyToken(req: Request): User | null {
+  // Accept token from Authorization header or ?token= query parameter
+  const authHeader = req.headers['authorization'];
+  const rawToken = (authHeader && authHeader.split(' ')[1]) || (req.query.token as string | undefined);
+  if (!rawToken) return null;
 
   // Long-lived MCP API token (trek_...)
-  if (token.startsWith('trek_')) {
-    return verifyMcpToken(token);
+  if (rawToken.startsWith('trek_')) {
+    return verifyMcpToken(rawToken);
   }
 
   // Short-lived JWT
-  return verifyJwtToken(token);
+  return verifyJwtToken(rawToken);
 }
 
 export async function mcpHandler(req: Request, res: Response): Promise<void> {
@@ -87,7 +89,7 @@ export async function mcpHandler(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const user = verifyToken(req.headers['authorization']);
+  const user = verifyToken(req);
   if (!user) {
     res.status(401).json({ error: 'Access token required' });
     return;

--- a/server/src/mcp/index.ts
+++ b/server/src/mcp/index.ts
@@ -72,16 +72,16 @@ function verifyToken(req: Request): User | null {
   // Accept token from Authorization header or ?token= query parameter
   const authHeader = req.headers['authorization'];
   const queryToken = Array.isArray(req.query.token) ? req.query.token[0] : (req.query.token as string | undefined);
-  const rawToken = (authHeader && authHeader.split(' ')[1]) || queryToken;
-  if (!rawToken) return null;
+  const token = (authHeader && authHeader.split(' ')[1]) || queryToken;
+  if (!token) return null;
 
   // Long-lived MCP API token (trek_...)
-  if (rawToken.startsWith('trek_')) {
-    return verifyMcpToken(rawToken);
+  if (token.startsWith('trek_')) {
+    return verifyMcpToken(token);
   }
 
   // Short-lived JWT
-  return verifyJwtToken(rawToken);
+  return verifyJwtToken(token);
 }
 
 export async function mcpHandler(req: Request, res: Response): Promise<void> {

--- a/server/tests/integration/mcp.test.ts
+++ b/server/tests/integration/mcp.test.ts
@@ -202,21 +202,20 @@ describe('MCP API token auth', () => {
     const token = generateToken(user.id);
     testDb.prepare("UPDATE addons SET enabled = 1 WHERE id = 'mcp'").run();
 
-    // First create a session via POST
-    const initRes = await request(app)
-      .post(`/mcp?token=${token}`)
-      .set('Accept', 'application/json, text/event-stream')
-      .send({ jsonrpc: '2.0', method: 'initialize', id: 1, params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' } } });
-    expect(initRes.status).toBe(200);
-    const sessionId = initRes.headers['mcp-session-id'];
-
-    // Then use session via GET with token in query param
+    // Auth passes: valid token in query param → 404 (unknown session), not 401
     const res = await request(app)
       .get(`/mcp?token=${token}`)
-      .set('Mcp-Session-Id', sessionId);
-    // Auth passes (may return 200 or other status depending on SSE, but not 401/403)
-    expect(res.status).not.toBe(401);
-    expect(res.status).not.toBe(403);
+      .set('Mcp-Session-Id', 'nonexistent-session-id');
+    expect(res.status).toBe(404);
+  });
+
+  it('MCP — POST /mcp with invalid token as ?token= query param returns 401', async () => {
+    testDb.prepare("UPDATE addons SET enabled = 1 WHERE id = 'mcp'").run();
+
+    const res = await request(app)
+      .post('/mcp?token=trek_totally_fake_token_not_in_db')
+      .send({ jsonrpc: '2.0', method: 'initialize', id: 1 });
+    expect(res.status).toBe(401);
   });
 });
 

--- a/server/tests/integration/mcp.test.ts
+++ b/server/tests/integration/mcp.test.ts
@@ -184,6 +184,40 @@ describe('MCP API token auth', () => {
       .send({ jsonrpc: '2.0', method: 'initialize', id: 1 });
     expect(res.status).toBe(401);
   });
+
+  it('MCP — POST /mcp with valid trek_ token as ?token= query param authenticates successfully', async () => {
+    const { user } = createUser(testDb);
+    const { rawToken } = createMcpToken(testDb, user.id);
+    testDb.prepare("UPDATE addons SET enabled = 1 WHERE id = 'mcp'").run();
+
+    const res = await request(app)
+      .post(`/mcp?token=${rawToken}`)
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', method: 'initialize', id: 1, params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' } } });
+    expect(res.status).toBe(200);
+  });
+
+  it('MCP — GET /mcp with valid JWT as ?token= query param passes auth', async () => {
+    const { user } = createUser(testDb);
+    const token = generateToken(user.id);
+    testDb.prepare("UPDATE addons SET enabled = 1 WHERE id = 'mcp'").run();
+
+    // First create a session via POST
+    const initRes = await request(app)
+      .post(`/mcp?token=${token}`)
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', method: 'initialize', id: 1, params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' } } });
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers['mcp-session-id'];
+
+    // Then use session via GET with token in query param
+    const res = await request(app)
+      .get(`/mcp?token=${token}`)
+      .set('Mcp-Session-Id', sessionId);
+    // Auth passes (may return 200 or other status depending on SSE, but not 401/403)
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
 });
 
 describe('MCP session management', () => {


### PR DESCRIPTION
This pull request adds support for authenticating MCP API requests using a token provided as a URL query parameter (`?token=...`), in addition to the existing `Authorization` header method. 

This makes it easier for clients that cannot set custom headers to authenticate. A new integration tests are added to verify the behavior.

Copilot was used to quickly identify where the validation of the MCP-Token is taking place. 
