### PR TITLE
docs: Clarify FORCE_HTTPS and TRUST_PROXY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ services:
       start_period: 15s
 ```
 
+This example is aimed at reverse-proxy deployments. If you access TREK directly on `http://<host>:3000` without nginx, Caddy, Traefik, or another TLS-terminating proxy in front of it, set `FORCE_HTTPS=false` and remove `TRUST_PROXY` to avoid redirects to a non-existent HTTPS endpoint.
+
 ```bash
 docker compose up -d
 ```
@@ -283,9 +285,9 @@ trek.yourdomain.com {
 | `TZ` | Timezone for logs, reminders and cron jobs (e.g. `Europe/Berlin`) | `UTC` |
 | `LOG_LEVEL` | `info` = concise user actions, `debug` = verbose details | `info` |
 | `ALLOWED_ORIGINS` | Comma-separated origins for CORS and email links | same-origin |
-| `FORCE_HTTPS` | Redirect HTTP to HTTPS behind a TLS-terminating proxy | `false` |
+| `FORCE_HTTPS` | Redirect HTTP to HTTPS behind a TLS-terminating proxy. If you access TREK directly on `http://host:3000`, keep this `false`. | `false` |
 | `COOKIE_SECURE` | Set to `false` to allow session cookies over plain HTTP (e.g. accessing via IP without HTTPS). Defaults to `true` in production. **Not recommended to disable in production.** | `true` |
-| `TRUST_PROXY` | Number of trusted reverse proxies for `X-Forwarded-For` | `1` |
+| `TRUST_PROXY` | Number of trusted reverse proxies for `X-Forwarded-For`. Use this only when TREK is actually behind a reverse proxy. | `1` |
 | `ALLOW_INTERNAL_NETWORK` | Allow outbound requests to private/RFC-1918 IP addresses. Set to `true` if Immich or other integrated services are hosted on your local network. Loopback (`127.x`) and link-local/metadata addresses (`169.254.x`) are always blocked regardless of this setting. | `false` |
 | `APP_URL` | Public base URL of this instance (e.g. `https://trek.example.com`). Required when OIDC is enabled — must match the redirect URI registered with your IdP. Also used as the base URL for external links in email notifications. | — |
 | **OIDC / SSO** | | |


### PR DESCRIPTION
## Summary

This PR improves the documentation for `FORCE_HTTPS` and `TRUST_PROXY` environment variables to prevent common configuration issues that cause infinite redirect loops.

## Changes Made

### README.md
1. **FORCE_HTTPS documentation** (line 288):
   - Added explicit warning: "If you access TREK directly on `http://host:3000`, keep this `false`."
   - Clear guidance for direct access scenarios

2. **TRUST_PROXY documentation** (line 290):
   - Clarified that this should only be used "when TREK is actually behind a reverse proxy"
   - Prevents misconfiguration when not using a reverse proxy

3. **Docker Compose example** (around line 176):
   - Added warning: "If you access TREK directly on `http://<host>:3000` without nginx, Caddy, Traefik, or another TLS-terminating proxy in front of it, set `FORCE_HTTPS=false` and remove `TRUST_PROXY`"

## Problem Solved

This fixes the issue where:
- Users set `FORCE_HTTPS=true` but access directly via `http://host:3000`
- The app redirects all requests to HTTPS, causing connection failures
- Users experience confusing behavior and cannot access their TREK instance

## Testing

The changes are documentation-only and don't affect code behavior. The documentation now clearly explains:
- When to use `FORCE_HTTPS=true` (with reverse proxy)
- When to use `FORCE_HTTPS=false` (direct access)
- When to use `TRUST_PROXY` (only when behind a reverse proxy)

## Related Issue

Closes #531

## Example Configurations

### Direct Access (Recommended for beginners)
```yaml
environment:
  FORCE_HTTPS: false
  # TRUST_PROXY not needed
```

### Reverse Proxy (Production)
```yaml
environment:
  FORCE_HTTPS: true
  TRUST_PROXY: 1
```