### PR TITLE
README.md: doc update, nginx reverse proxy conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 50m;
     }
 }
 ```


### PR DESCRIPTION
When using nginx as a reverse proxy it might refuse file uploads because the default upload size is 1m only. TREK allows file sizes of up to 50m.

Thus set the `client_max_body_size` to `50m` in the nginx configuration.