### PR TITLE
docs: clarify reverse-proxy HTTPS guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ services:
       - TZ=${TZ:-UTC} # Timezone for logs, reminders and scheduled tasks (e.g. Europe/Berlin)
       - LOG_LEVEL=${LOG_LEVEL:-info} # info = concise user actions; debug = verbose admin-level details
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-} # Comma-separated origins for CORS and email notification links
-      - FORCE_HTTPS=true # Redirect HTTP to HTTPS when behind a TLS-terminating proxy
+      # - FORCE_HTTPS=true # Optional: let TREK send HTTP->HTTPS redirects and HSTS behind a TLS-terminating proxy
       # - COOKIE_SECURE=false # Uncomment if accessing over plain HTTP (no HTTPS). Not recommended for production.
-      - TRUST_PROXY=1 # Number of trusted proxies for X-Forwarded-For
+      - TRUST_PROXY=1 # Trust X-Forwarded-* headers from your reverse proxy
       # - ALLOW_INTERNAL_NETWORK=true # Uncomment if Immich or other services are on your local network (RFC-1918 IPs)
       - APP_URL=${APP_URL:-} # Base URL of this instance — required when OIDC is enabled; must match the redirect URI registered with your IdP; Also used as the base URL for email notifications and other external links
       # - OIDC_ISSUER=https://auth.example.com # OpenID Connect provider URL
@@ -180,7 +180,11 @@ services:
       start_period: 15s
 ```
 
-This example is aimed at reverse-proxy deployments. If you access TREK directly on `http://<host>:3000` without nginx, Caddy, Traefik, or another TLS-terminating proxy in front of it, set `FORCE_HTTPS=false` and remove `TRUST_PROXY` to avoid redirects to a non-existent HTTPS endpoint.
+This example is aimed at reverse-proxy deployments. `TRUST_PROXY=1` is the important part here so Express trusts `X-Forwarded-*` headers from nginx, Caddy, Traefik, or another proxy in front of TREK.
+
+`FORCE_HTTPS` is optional in that setup: enable it only if you want TREK itself to send HTTP->HTTPS redirects and HSTS headers. If your reverse proxy already enforces HTTPS, leaving `FORCE_HTTPS=false` is fine.
+
+If you access TREK directly on `http://<host>:3000` without a TLS-terminating proxy in front of it, leave `FORCE_HTTPS=false` and remove `TRUST_PROXY` to avoid redirects to a non-existent HTTPS endpoint.
 
 ```bash
 docker compose up -d
@@ -291,9 +295,9 @@ trek.yourdomain.com {
 | `TZ` | Timezone for logs, reminders and cron jobs (e.g. `Europe/Berlin`) | `UTC` |
 | `LOG_LEVEL` | `info` = concise user actions, `debug` = verbose details | `info` |
 | `ALLOWED_ORIGINS` | Comma-separated origins for CORS and email links | same-origin |
-| `FORCE_HTTPS` | Redirect HTTP to HTTPS behind a TLS-terminating proxy. If you access TREK directly on `http://host:3000`, keep this `false`. | `false` |
+| `FORCE_HTTPS` | Optional application-layer HTTPS enforcement. Enable this only if TREK is behind a TLS-terminating proxy that forwards `X-Forwarded-Proto` and you want TREK itself to send HTTP->HTTPS redirects and HSTS. If your proxy already enforces HTTPS, or you access TREK directly on `http://host:3000`, keep this `false`. | `false` |
 | `COOKIE_SECURE` | Set to `false` to allow session cookies over plain HTTP (e.g. accessing via IP without HTTPS). Defaults to `true` in production. **Not recommended to disable in production.** | `true` |
-| `TRUST_PROXY` | Number of trusted reverse proxies for `X-Forwarded-For`. Use this only when TREK is actually behind a reverse proxy. | `1` |
+| `TRUST_PROXY` | Number of trusted reverse proxies in front of TREK so Express trusts `X-Forwarded-*` headers for client IP and forwarded protocol handling. Use this only when TREK is actually behind a reverse proxy. | `1` |
 | `ALLOW_INTERNAL_NETWORK` | Allow outbound requests to private/RFC-1918 IP addresses. Set to `true` if Immich or other integrated services are hosted on your local network. Loopback (`127.x`) and link-local/metadata addresses (`169.254.x`) are always blocked regardless of this setting. | `false` |
 | `APP_URL` | Public base URL of this instance (e.g. `https://trek.example.com`). Required when OIDC is enabled — must match the redirect URI registered with your IdP. Also used as the base URL for external links in email notifications. | — |
 | **OIDC / SSO** | | |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,11 +25,11 @@ env:
   # Public base URL of this instance. Required when OIDC is enabled — must match the redirect URI registered with your IdP.
   # Also used as the base URL for links in email notifications and other external links.
   # FORCE_HTTPS: "false"
-  # Set to "true" to redirect HTTP to HTTPS behind a TLS-terminating proxy.
+  # Optional: set to "true" to let TREK send HTTP->HTTPS redirects and HSTS behind a TLS-terminating proxy.
   # COOKIE_SECURE: "true"
   # Set to "false" to allow session cookies over plain HTTP (e.g. no ingress TLS). Not recommended for production.
   # TRUST_PROXY: "1"
-  # Number of trusted reverse proxies for X-Forwarded-For header parsing.
+  # Number of trusted reverse proxies so Express trusts X-Forwarded-* headers.
   # ALLOW_INTERNAL_NETWORK: "false"
   # Set to "true" if Immich or other integrated services are hosted on a private/RFC-1918 network address.
   # Loopback (127.x) and link-local/metadata addresses (169.254.x) are always blocked.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
       - TZ=${TZ:-UTC} # Timezone for logs, reminders and scheduled tasks (e.g. Europe/Berlin)
       - LOG_LEVEL=${LOG_LEVEL:-info} # info = concise user actions; debug = verbose admin-level details
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-} # Comma-separated origins for CORS and email notification links
-      - FORCE_HTTPS=true # Redirect HTTP to HTTPS when behind a TLS-terminating proxy
+      # - FORCE_HTTPS=true # Optional: let TREK send HTTP->HTTPS redirects and HSTS behind a TLS-terminating proxy
 #     - COOKIE_SECURE=false # Uncomment if accessing over plain HTTP (no HTTPS). Not recommended for production.
-      - TRUST_PROXY=1 # Number of trusted proxies (for X-Forwarded-For / real client IP)
+      - TRUST_PROXY=1 # Trust X-Forwarded-* headers from your reverse proxy (client IP / forwarded protocol)
       - ALLOW_INTERNAL_NETWORK=false # Set to true if Immich or other services are hosted on your local network (RFC-1918 IPs). Loopback and link-local addresses remain blocked regardless.
 #      - APP_URL=https://trek.example.com # Public base URL — required when OIDC is enabled (must match the redirect URI registered with your IdP); also used as base URL for links in email notifications
 #      - OIDC_ISSUER=https://auth.example.com # OpenID Connect provider URL


### PR DESCRIPTION
## Description
Clarifies the reverse-proxy deployment docs so `TRUST_PROXY` and `FORCE_HTTPS` are documented separately.

The current wording makes `FORCE_HTTPS=true` look like the default/required setting whenever TREK sits behind a reverse proxy. This PR updates the README, Docker Compose example, and Helm values comments to explain that:

- `TRUST_PROXY` is what enables Express to trust `X-Forwarded-*` headers from the proxy
- `FORCE_HTTPS` is optional and only needed if TREK itself should emit HTTP -> HTTPS redirects and HSTS
- direct `http://host:3000` deployments should still leave `FORCE_HTTPS=false` and avoid `TRUST_PROXY`

## Related Issue or Discussion
Closes #559

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [ ] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed

Docs-only change, so no runtime tests were added or run.
