### PR TITLE
fix(atlas): add A3 fallback when ISO_A2 is invalid

### DIFF
--- a/client/src/pages/AtlasPage.test.tsx
+++ b/client/src/pages/AtlasPage.test.tsx
@@ -127,6 +127,23 @@ const geoJsonWithFR = {
   ],
 };
 
+const geoJsonWithFranceA3Fallback = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {
+        ISO_A2: '-99',
+        ADM0_A3: 'FRA',
+        ISO_A3: 'FRA',
+        NAME: 'France',
+        ADMIN: 'France',
+      },
+      geometry: null,
+    },
+  ],
+};
+
 // ── Atlas API response fixture ────────────────────────────────────────────────
 const atlasStatsResponse = {
   countries: [{ code: 'FR', tripCount: 2, placeCount: 5, firstVisit: '2023-01-01', lastVisit: '2024-06-01' }],
@@ -1320,6 +1337,33 @@ describe('AtlasPage', () => {
 
       // XK is not in A2_TO_A3_BASE, so the geoJSON loop covers the `A2_TO_A3[a2] = a3` line
       expect(screen.getAllByText(/countries/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('FE-PAGE-ATLAS-041: country search falls back from A3 when ISO_A2 is invalid', () => {
+    it('returns France in search results when GeoJSON provides ADM0_A3 but ISO_A2 is -99', async () => {
+      vi.spyOn(global, 'fetch').mockImplementation((url) => {
+        const urlStr = String(url);
+        if (urlStr.includes('geojson') || urlStr.includes('githubusercontent')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(geoJsonWithFranceA3Fallback) } as Response);
+        }
+        return Promise.reject(new Error(`Unmocked fetch: ${urlStr}`));
+      });
+
+      const user = userEvent.setup();
+      render(<AtlasPage />);
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search a country/i)).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByPlaceholderText(/search a country/i);
+      await user.type(searchInput, 'france');
+
+      await waitFor(() => {
+        const franceButton = screen.getAllByRole('button').find((button) => button.textContent?.includes('France'));
+        expect(franceButton).toBeTruthy();
+      });
     });
   });
 

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -189,8 +189,15 @@ export default function AtlasPage(): React.ReactElement {
     const opts: { code: string; label: string }[] = []
     const seen = new Set<string>()
     for (const f of (geoData as any).features || []) {
-      const a2 = f?.properties?.ISO_A2
-      if (!a2 || a2 === '-99' || typeof a2 !== 'string' || a2.length !== 2) continue
+      let a2 = f?.properties?.ISO_A2
+      if (!a2 || a2 === '-99' || typeof a2 !== 'string' || a2.length !== 2) {
+        const a3 = f?.properties?.ADM0_A3 || f?.properties?.ISO_A3 || f?.properties?.['ISO3166-1-Alpha-3'] || null
+        if (a3 && a3 !== '-99') {
+          const a3ToA2Entry = Object.entries(A2_TO_A3).find(([, v]) => v === a3)
+          a2 = a3ToA2Entry ? a3ToA2Entry[0] : null
+        }
+      }
+      if (!a2 || typeof a2 !== 'string' || a2.length !== 2) continue
       if (seen.has(a2)) continue
       seen.add(a2)
       const label = String(resolveName(a2) || f?.properties?.NAME || f?.properties?.ADMIN || a2)


### PR DESCRIPTION
## Description
In Atlas search, France and Norway (maybe more) aren't being returned.

### Cause
1. The search list is built from GeoJSON features using only `properties.ISO_A2`: AtlasPage.tsx:192
2. Any feature with `ISO_A2` equal to -99 is skipped: AtlasPage.tsx:193
3. France in this Natural Earth dataset is one of the countries represented via non-standard `ISO_A2` in some records, so it gets excluded from `atlas_country_options`.
4. Then the input only filters `atlas_country_options`: AtlasPage.tsx:804

### Fix
In the search-option builder, add a fallback when ISO_A2 is invalid (-99), using ADM0_A3/ISO_A3 and reverse-mapping to A2 (you already do similar A3/A2 handling in map feature logic around AtlasPage.tsx:434

## Screenshots

| France | Norway |
|--------|--------|
|  <img width="1582" height="1035" alt="France" src="https://github.com/user-attachments/assets/b9cd35f1-4795-4f37-b9a4-8165634e28ce" /> |  <img width="1582" height="1035" alt="Norway" src="https://github.com/user-attachments/assets/3392727e-94bd-47d4-82e2-11c681891b65" /> |

## Related Issue or Discussion
<!-- This project requires an issue or an approved feature request before submitting a PR. -->
<!-- For bug fixes: Closes #ISSUE_NUMBER -->
<!-- For features: Addresses discussion #DISCUSSION_NUMBER -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
