### PR TITLE
Fix journey map OSM warning, sidebar re-render & migration 98 ambiguous column

### DIFF
--- a/client/src/components/Journey/JourneyMap.tsx
+++ b/client/src/components/Journey/JourneyMap.tsx
@@ -155,7 +155,7 @@ const JourneyMap = forwardRef<JourneyMapHandle, Props>(function JourneyMap(
 
     const map = L.map(containerRef.current, {
       zoomControl: false,
-      attributionControl: false,
+      attributionControl: true,
       scrollWheelZoom: false,
       dragging: true,
       touchZoom: true,
@@ -165,7 +165,10 @@ const JourneyMap = forwardRef<JourneyMapHandle, Props>(function JourneyMap(
     const defaultTile = dark
       ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
       : 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png'
-    L.tileLayer(mapTileUrl || defaultTile, { maxZoom: 18 }).addTo(map)
+    L.tileLayer(mapTileUrl || defaultTile, {
+      maxZoom: 18,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map)
 
     const items = buildMarkerItems(entries)
     itemsRef.current = items

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -158,6 +158,16 @@ export default function JourneyDetailPage() {
     [current?.entries]
   )
 
+  const sidebarMapItems = useMemo(() => mapEntries.map(e => ({
+    id: String(e.id),
+    lat: e.location_lat!,
+    lng: e.location_lng!,
+    title: e.title || '',
+    mood: e.mood,
+    created_at: e.entry_date,
+    entry_date: e.entry_date,
+  })), [mapEntries])
+
   const tripDates = useMemo(() => {
     const dates = new Set<string>()
     if (!current?.trips) return dates
@@ -387,17 +397,9 @@ export default function JourneyDetailPage() {
                 <JourneyMap
                   ref={mapRef}
                   checkins={[]}
-                  entries={mapEntries.map(e => ({
-                    id: String(e.id),
-                    lat: e.location_lat!,
-                    lng: e.location_lng!,
-                    title: e.title || '',
-                    mood: e.mood,
-                    created_at: e.entry_date,
-                    entry_date: e.entry_date,
-                  })) as any}
+                  entries={sidebarMapItems as any}
                   height={240}
-                  onMarkerClick={(id) => handleMarkerClick(id)}
+                  onMarkerClick={handleMarkerClick}
                 />
                 <div className="px-3.5 py-2.5 border-t border-zinc-200 dark:border-zinc-700 flex items-center justify-between text-[11px] text-zinc-500">
                   <span>{mapEntries.length} {t('journey.stats.places')}</span>


### PR DESCRIPTION
## Summary
- Fix OpenStreetMap usage warning on journey map by enabling attribution control and adding proper attribution string (#627)
- Fix journey sidebar map re-rendering on every tab switch by memoizing the entries array and using a stable callback reference (#610)
- Fix migration 98 crash caused by ambiguous `provider` column in JOIN between trip_photos and trek_photos