### PR TITLE
fix(places): add notes field to place edit form

### DIFF
--- a/client/src/components/Planner/PlaceFormModal.tsx
+++ b/client/src/components/Planner/PlaceFormModal.tsx
@@ -290,6 +290,19 @@ export default function PlaceFormModal({
           />
         </div>
 
+        {/* Notes */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">{t('places.formNotes')}</label>
+          <textarea
+            value={form.notes}
+            onChange={e => handleChange('notes', e.target.value)}
+            rows={3}
+            maxLength={2000}
+            placeholder={t('places.formNotesPlaceholder')}
+            className="form-input" style={{ resize: 'vertical' }}
+          />
+        </div>
+
         {/* Address + Coordinates */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">{t('places.formAddress')}</label>

--- a/client/src/components/Planner/PlaceInspector.tsx
+++ b/client/src/components/Planner/PlaceInspector.tsx
@@ -341,9 +341,16 @@ export default function PlaceInspector({
           )}
 
           {/* Description / Summary */}
-          {(place.description || place.notes || googleDetails?.summary) && (
+          {(place.description || googleDetails?.summary) && (
             <div className="collab-note-md" style={{ background: 'var(--bg-hover)', borderRadius: 10, overflow: 'hidden', fontSize: 12, color: 'var(--text-muted)', lineHeight: '1.5', padding: '8px 12px' }}>
-              <Markdown remarkPlugins={[remarkGfm]}>{place.description || place.notes || googleDetails?.summary || ''}</Markdown>
+              <Markdown remarkPlugins={[remarkGfm]}>{place.description || googleDetails?.summary || ''}</Markdown>
+            </div>
+          )}
+
+          {/* Notes */}
+          {place.notes && (
+            <div className="collab-note-md" style={{ background: 'var(--bg-hover)', borderRadius: 10, overflow: 'hidden', fontSize: 12, color: 'var(--text-muted)', lineHeight: '1.5', padding: '8px 12px' }}>
+              <Markdown remarkPlugins={[remarkGfm]}>{place.notes}</Markdown>
             </div>
           )}
 

--- a/client/src/i18n/translations/ar.ts
+++ b/client/src/i18n/translations/ar.ts
@@ -927,6 +927,7 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'وقت النهاية قبل وقت البداية',
   'places.timeCollision': 'تداخل في الوقت مع:',
   'places.formWebsite': 'الموقع الإلكتروني',
+  'places.formNotes': 'ملاحظات',
   'places.formNotesPlaceholder': 'ملاحظات شخصية...',
   'places.formReservation': 'حجز',
   'places.reservationNotesPlaceholder': 'ملاحظات الحجز، رقم التأكيد...',

--- a/client/src/i18n/translations/br.ts
+++ b/client/src/i18n/translations/br.ts
@@ -897,6 +897,7 @@ const br: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'O horário de fim é antes do início',
   'places.timeCollision': 'Sobreposição de horário com:',
   'places.formWebsite': 'Site',
+  'places.formNotes': 'Notas',
   'places.formNotesPlaceholder': 'Notas pessoais...',
   'places.formReservation': 'Reserva',
   'places.reservationNotesPlaceholder': 'Notas da reserva, código de confirmação...',

--- a/client/src/i18n/translations/cs.ts
+++ b/client/src/i18n/translations/cs.ts
@@ -925,6 +925,7 @@ const cs: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'Čas konce je před časem začátku',
   'places.timeCollision': 'Časový překryv s:',
   'places.formWebsite': 'Webové stránky',
+  'places.formNotes': 'Poznámky',
   'places.formNotesPlaceholder': 'Osobní poznámky...',
   'places.formReservation': 'Rezervace',
   'places.reservationNotesPlaceholder': 'Poznámky k rezervaci, potvrzovací kód...',

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -928,6 +928,7 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'Endzeit liegt vor der Startzeit',
   'places.timeCollision': 'Zeitliche Überschneidung mit:',
   'places.formWebsite': 'Website',
+  'places.formNotes': 'Notizen',
   'places.formNotesPlaceholder': 'Persönliche Notizen...',
   'places.formReservation': 'Reservierung',
   'places.reservationNotesPlaceholder': 'Reservierungsnotizen, Bestätigungsnummer...',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -950,6 +950,7 @@ const en: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'End time is before start time',
   'places.timeCollision': 'Time overlap with:',
   'places.formWebsite': 'Website',
+  'places.formNotes': 'Notes',
   'places.formNotesPlaceholder': 'Personal notes...',
   'places.formReservation': 'Reservation',
   'places.reservationNotesPlaceholder': 'Reservation notes, confirmation number...',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -900,6 +900,7 @@ const es: Record<string, string> = {
   'places.endTimeBeforeStart': 'La hora de fin es anterior a la de inicio',
   'places.timeCollision': 'Solapamiento horario con:',
   'places.formWebsite': 'Página web',
+  'places.formNotes': 'Notas',
   'places.formNotesPlaceholder': 'Notas personales...',
   'places.formReservation': 'Reserva',
   'places.reservationNotesPlaceholder': 'Notas de reserva, número de confirmación...',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -924,6 +924,7 @@ const fr: Record<string, string> = {
   'places.endTimeBeforeStart': 'L\'heure de fin est antérieure à l\'heure de début',
   'places.timeCollision': 'Chevauchement horaire avec :',
   'places.formWebsite': 'Site web',
+  'places.formNotes': 'Notes',
   'places.formNotesPlaceholder': 'Notes personnelles…',
   'places.formReservation': 'Réservation',
   'places.reservationNotesPlaceholder': 'Notes de réservation, numéro de confirmation…',

--- a/client/src/i18n/translations/hu.ts
+++ b/client/src/i18n/translations/hu.ts
@@ -925,6 +925,7 @@ const hu: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'A befejezési idő a kezdési idő előtt van',
   'places.timeCollision': 'Időbeli átfedés:',
   'places.formWebsite': 'Weboldal',
+  'places.formNotes': 'Jegyzetek',
   'places.formNotesPlaceholder': 'Személyes jegyzetek...',
   'places.formReservation': 'Foglalás',
   'places.reservationNotesPlaceholder': 'Foglalási jegyzetek, visszaigazolási szám...',

--- a/client/src/i18n/translations/it.ts
+++ b/client/src/i18n/translations/it.ts
@@ -925,6 +925,7 @@ const it: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'L\'ora di fine è precedente all\'ora di inizio',
   'places.timeCollision': 'Sovrapposizione di orario con:',
   'places.formWebsite': 'Sito web',
+  'places.formNotes': 'Note',
   'places.formNotesPlaceholder': 'Note personali...',
   'places.formReservation': 'Prenotazione',
   'places.reservationNotesPlaceholder': 'Note della prenotazione, numero di conferma...',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -924,6 +924,7 @@ const nl: Record<string, string> = {
   'places.endTimeBeforeStart': 'Eindtijd is vóór de starttijd',
   'places.timeCollision': 'Tijdoverlap met:',
   'places.formWebsite': 'Website',
+  'places.formNotes': 'Notities',
   'places.formNotesPlaceholder': 'Persoonlijke notities...',
   'places.formReservation': 'Reservering',
   'places.reservationNotesPlaceholder': 'Reserveringsnotities, bevestigingsnummer...',

--- a/client/src/i18n/translations/pl.ts
+++ b/client/src/i18n/translations/pl.ts
@@ -886,6 +886,7 @@ const pl: Record<string, string | { name: string; category: string }[]> = {
   'places.endTimeBeforeStart': 'Godzina zakończenia jest przed godziną rozpoczęcia',
   'places.timeCollision': 'Nakładanie się godzin z:',
   'places.formWebsite': 'Strona internetowa',
+  'places.formNotes': 'Notatki',
   'places.formNotesPlaceholder': 'Osobiste notatki...',
   'places.formReservation': 'Rezerwacja',
   'places.reservationNotesPlaceholder': 'Notatki z rezerwacji, numer potwierdzenia...',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -924,6 +924,7 @@ const ru: Record<string, string> = {
   'places.endTimeBeforeStart': 'Время окончания раньше времени начала',
   'places.timeCollision': 'Пересечение по времени с:',
   'places.formWebsite': 'Сайт',
+  'places.formNotes': 'Заметки',
   'places.formNotesPlaceholder': 'Личные заметки...',
   'places.formReservation': 'Бронирование',
   'places.reservationNotesPlaceholder': 'Заметки о бронировании, номер подтверждения...',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -924,6 +924,7 @@ const zh: Record<string, string> = {
   'places.endTimeBeforeStart': '结束时间早于开始时间',
   'places.timeCollision': '时间冲突：',
   'places.formWebsite': '网站',
+  'places.formNotes': '备注',
   'places.formNotesPlaceholder': '个人备注...',
   'places.formReservation': '预订',
   'places.reservationNotesPlaceholder': '预订备注、确认号...',

--- a/client/src/i18n/translations/zhTw.ts
+++ b/client/src/i18n/translations/zhTw.ts
@@ -949,6 +949,7 @@ const zhTw: Record<string, string> = {
   'places.endTimeBeforeStart': '結束時間早於開始時間',
   'places.timeCollision': '時間衝突：',
   'places.formWebsite': '網站',
+  'places.formNotes': '備註',
   'places.formNotesPlaceholder': '個人備註...',
   'places.formReservation': '預訂',
   'places.reservationNotesPlaceholder': '預訂備註、確認號...',

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -43,18 +43,24 @@ export interface Place {
   trip_id: number
   name: string
   description: string | null
+  notes: string | null
   lat: number | null
   lng: number | null
   address: string | null
   category_id: number | null
   icon: string | null
   price: string | null
+  currency: string | null
   image_url: string | null
   google_place_id: string | null
   osm_id: string | null
   route_geometry: string | null
   place_time: string | null
   end_time: string | null
+  duration_minutes: number | null
+  transport_mode: string | null
+  website: string | null
+  phone: string | null
   created_at: string
 }
 


### PR DESCRIPTION
- Add notes textarea to PlaceFormModal — field was writable via MCP but had no UI input
- Add missing notes (and currency, duration_minutes, transport_mode, website, phone) to client Place type
- Fix PlaceInspector to render description and notes as separate blocks (previously description || notes hid notes when description existed)

Closes #596

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [ ] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [ ] This PR targets the `dev` branch, not `main`
- [ ] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
