### PR TITLE
Journey Bug Fixes #2

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -322,6 +322,9 @@ export const journeyApi = {
   updateContributor: (id: number, userId: number, role: string) => apiClient.patch(`/journeys/${id}/contributors/${userId}`, { role }).then(r => r.data),
   removeContributor: (id: number, userId: number) => apiClient.delete(`/journeys/${id}/contributors/${userId}`).then(r => r.data),
 
+  // Preferences
+  updatePreferences: (id: number, data: { hide_skeletons?: boolean }) => apiClient.patch(`/journeys/${id}/preferences`, data).then(r => r.data),
+
   // Share
   getShareLink: (id: number) => apiClient.get(`/journeys/${id}/share-link`).then(r => r.data),
   createShareLink: (id: number, perms: { share_timeline?: boolean; share_gallery?: boolean; share_map?: boolean }) => apiClient.post(`/journeys/${id}/share-link`, perms).then(r => r.data),

--- a/client/src/components/Admin/AddonManager.test.tsx
+++ b/client/src/components/Admin/AddonManager.test.tsx
@@ -190,11 +190,12 @@ describe('AddonManager', () => {
     expect(screen.queryByText('Bag Tracking')).not.toBeInTheDocument();
   });
 
-  it('FE-ADMIN-ADDON-010: photo provider sub-toggles shown for Memories addon', async () => {
+  it('FE-ADMIN-ADDON-010: photo provider sub-toggles shown under Journey addon', async () => {
     server.use(
       http.get('/api/admin/addons', () =>
         HttpResponse.json({
           addons: [
+            buildAddon({ id: 'journey', name: 'Journey', type: 'global', icon: 'Compass', enabled: true }),
             buildAddon({ id: 'photos', name: 'Memories', type: 'trip', icon: 'Image', enabled: false }),
             buildAddon({ id: 'unsplash', name: 'Unsplash', type: 'photo_provider', enabled: true }),
             buildAddon({ id: 'pexels', name: 'Pexels', type: 'photo_provider', enabled: false }),
@@ -204,18 +205,16 @@ describe('AddonManager', () => {
     );
     render(<AddonManager />);
 
-    // Provider sub-rows are visible
+    // Provider sub-rows are visible under Journey addon
     await screen.findByText('Unsplash');
     expect(screen.getByText('Pexels')).toBeInTheDocument();
 
-    // Memories row shows name override
-    expect(screen.getByText('Memories providers')).toBeInTheDocument();
+    // Journey addon is rendered
+    expect(screen.getByText('Journey')).toBeInTheDocument();
 
-    // The photos addon row itself has no top-level toggle (hideToggle = true)
-    // The toggle buttons are only for the providers
+    // Toggle buttons: journey toggle + 2 provider toggles
     const toggleBtns = screen.getAllByRole('button').filter(b => b.classList.contains('rounded-full'));
-    // Should be 2 provider toggles (no main toggle for the photos addon)
-    expect(toggleBtns.length).toBe(2);
+    expect(toggleBtns.length).toBe(3);
   });
 
   it('FE-ADMIN-ADDON-011: icon falls back to Puzzle when icon name unknown', async () => {

--- a/client/src/components/Admin/AddonManager.tsx
+++ b/client/src/components/Admin/AddonManager.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from '../../i18n'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useAddonStore } from '../../store/addonStore'
 import { useToast } from '../shared/Toast'
-import { Puzzle, ListChecks, Wallet, FileText, CalendarDays, Globe, Briefcase, Image, Terminal, Link2, Compass } from 'lucide-react'
+import { Puzzle, ListChecks, Wallet, FileText, CalendarDays, Globe, Briefcase, Image, Terminal, Link2, Compass, BookOpen } from 'lucide-react'
 
 const ICON_MAP = {
-  ListChecks, Wallet, FileText, CalendarDays, Puzzle, Globe, Briefcase, Image, Terminal, Link2, Compass,
+  ListChecks, Wallet, FileText, CalendarDays, Puzzle, Globe, Briefcase, Image, Terminal, Link2, Compass, BookOpen,
 }
 
 interface Addon {
@@ -103,11 +103,11 @@ export default function AddonManager({ bagTrackingEnabled, onToggleBagTracking }
     }
   }
 
-  const tripAddons = addons.filter(a => a.type === 'trip')
-  const globalAddons = addons.filter(a => a.type === 'global')
   const photoProviderAddons = addons.filter(isPhotoProviderAddon)
+  const photosAddon = addons.filter(a => a.type === 'trip').find(isPhotosAddon)
+  const tripAddons = addons.filter(a => a.type === 'trip' && !isPhotosAddon(a))
+  const globalAddons = addons.filter(a => a.type === 'global')
   const integrationAddons = addons.filter(a => a.type === 'integration')
-  const photosAddon = tripAddons.find(isPhotosAddon)
   const providerOptions: ProviderOption[] = photoProviderAddons.map((provider) => ({
       key: provider.id,
       label: provider.name,
@@ -153,42 +153,7 @@ export default function AddonManager({ bagTrackingEnabled, onToggleBagTracking }
                 </div>
                 {tripAddons.map(addon => (
                   <div key={addon.id}>
-                    <AddonRow
-                      addon={addon}
-                      onToggle={handleToggle}
-                      t={t}
-                      nameOverride={photosAddon && addon.id === photosAddon.id ? 'Memories providers' : undefined}
-                      descriptionOverride={photosAddon && addon.id === photosAddon.id ? 'Enable or disable each photo provider.' : undefined}
-                      statusOverride={photosAddon && addon.id === photosAddon.id ? photosDerivedEnabled : undefined}
-                      hideToggle={photosAddon && addon.id === photosAddon.id}
-                    />
-                    {photosAddon && addon.id === photosAddon.id && providerOptions.length > 0 && (
-                      <div className="px-6 py-3 border-b" style={{ borderColor: 'var(--border-secondary)', background: 'var(--bg-secondary)', paddingLeft: 70 }}>
-                        <div className="space-y-2">
-                          {providerOptions.map(provider => (
-                            <div key={provider.key} className="flex items-center gap-4" style={{ minHeight: 32 }}>
-                              <div style={{ flex: 1, minWidth: 0 }}>
-                                <div className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>{provider.label}</div>
-                                <div className="text-xs mt-0.5" style={{ color: 'var(--text-faint)' }}>{provider.description}</div>
-                              </div>
-                              <div className="flex items-center gap-2 shrink-0">
-                                <span className="hidden sm:inline text-xs font-medium" style={{ color: provider.enabled ? 'var(--text-primary)' : 'var(--text-faint)' }}>
-                                  {provider.enabled ? t('admin.addons.enabled') : t('admin.addons.disabled')}
-                                </span>
-                                <button
-                                  onClick={provider.toggle}
-                                  className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors"
-                                  style={{ background: provider.enabled ? 'var(--text-primary)' : 'var(--border-primary)' }}
-                                >
-                                  <span className="absolute left-0.5 h-5 w-5 rounded-full bg-white transition-transform duration-200"
-                                    style={{ transform: provider.enabled ? 'translateX(20px)' : 'translateX(0)' }} />
-                                </button>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                    <AddonRow addon={addon} onToggle={handleToggle} t={t} />
                     {addon.id === 'packing' && addon.enabled && onToggleBagTracking && (
                       <div className="flex items-center gap-4 px-6 py-3 border-b" style={{ borderColor: 'var(--border-secondary)', background: 'var(--bg-secondary)', paddingLeft: 70 }}>
                         <div style={{ flex: 1, minWidth: 0 }}>
@@ -223,7 +188,37 @@ export default function AddonManager({ bagTrackingEnabled, onToggleBagTracking }
                   </span>
                 </div>
                 {globalAddons.map(addon => (
-                  <AddonRow key={addon.id} addon={addon} onToggle={handleToggle} t={t} />
+                  <div key={addon.id}>
+                    <AddonRow addon={addon} onToggle={handleToggle} t={t} />
+                    {/* Memories providers as sub-items under Journey addon */}
+                    {addon.id === 'journey' && providerOptions.length > 0 && (
+                      <div className="px-6 py-3 border-b" style={{ borderColor: 'var(--border-secondary)', background: 'var(--bg-secondary)', paddingLeft: 70 }}>
+                        <div className="space-y-2">
+                          {providerOptions.map(provider => (
+                            <div key={provider.key} className="flex items-center gap-4" style={{ minHeight: 32 }}>
+                              <div style={{ flex: 1, minWidth: 0 }}>
+                                <div className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>{provider.label}</div>
+                                <div className="text-xs mt-0.5" style={{ color: 'var(--text-faint)' }}>{provider.description}</div>
+                              </div>
+                              <div className="flex items-center gap-2 shrink-0">
+                                <span className="hidden sm:inline text-xs font-medium" style={{ color: provider.enabled ? 'var(--text-primary)' : 'var(--text-faint)' }}>
+                                  {provider.enabled ? t('admin.addons.enabled') : t('admin.addons.disabled')}
+                                </span>
+                                <button
+                                  onClick={provider.toggle}
+                                  className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors"
+                                  style={{ background: provider.enabled ? 'var(--text-primary)' : 'var(--border-primary)' }}
+                                >
+                                  <span className="absolute left-0.5 h-5 w-5 rounded-full bg-white transition-transform duration-200"
+                                    style={{ transform: provider.enabled ? 'translateX(20px)' : 'translateX(0)' }} />
+                                </button>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 ))}
               </div>
             )}

--- a/client/src/components/Journey/JourneyMap.tsx
+++ b/client/src/components/Journey/JourneyMap.tsx
@@ -168,7 +168,8 @@ const JourneyMap = forwardRef<JourneyMapHandle, Props>(function JourneyMap(
     L.tileLayer(mapTileUrl || defaultTile, {
       maxZoom: 18,
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    }).addTo(map)
+      referrerPolicy: 'strict-origin-when-cross-origin',
+    } as any).addTo(map)
 
     const items = buildMarkerItems(entries)
     itemsRef.current = items

--- a/client/src/components/Journey/MarkdownToolbar.tsx
+++ b/client/src/components/Journey/MarkdownToolbar.tsx
@@ -6,7 +6,7 @@ interface Props {
   dark?: boolean
 }
 
-type FormatAction = { type: 'wrap'; before: string; after: string } | { type: 'line'; prefix: string }
+type FormatAction = { type: 'wrap'; before: string; after: string } | { type: 'line'; prefix: string } | { type: 'insert'; text: string }
 
 const ACTIONS: Array<{ icon: typeof Bold; label: string; action: FormatAction }> = [
   { icon: Bold, label: 'Bold', action: { type: 'wrap', before: '**', after: '**' } },
@@ -16,7 +16,7 @@ const ACTIONS: Array<{ icon: typeof Bold; label: string; action: FormatAction }>
   { icon: Link, label: 'Link', action: { type: 'wrap', before: '[', after: '](url)' } },
   { icon: List, label: 'List', action: { type: 'line', prefix: '- ' } },
   { icon: ListOrdered, label: 'Ordered', action: { type: 'line', prefix: '1. ' } },
-  { icon: Minus, label: 'Divider', action: { type: 'line', prefix: '\n---\n' } },
+  { icon: Minus, label: 'Divider', action: { type: 'insert', text: '\n\n---\n\n' } },
 ]
 
 export default function MarkdownToolbar({ textareaRef, onUpdate, dark }: Props) {
@@ -35,6 +35,9 @@ export default function MarkdownToolbar({ textareaRef, onUpdate, dark }: Props) 
     if (action.type === 'wrap') {
       result = text.slice(0, start) + action.before + selected + action.after + text.slice(end)
       cursorPos = selected ? end + action.before.length + action.after.length : start + action.before.length
+    } else if (action.type === 'insert') {
+      result = text.slice(0, start) + action.text + text.slice(end)
+      cursorPos = start + action.text.length
     } else {
       // line prefix — find start of current line
       const lineStart = text.lastIndexOf('\n', start - 1) + 1

--- a/client/src/i18n/translations/ar.ts
+++ b/client/src/i18n/translations/ar.ts
@@ -1557,6 +1557,8 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
   'journey.detail.backToJourney': 'العودة للمجلة',
   'journey.detail.day': 'اليوم {number}',
   'journey.detail.places': 'أماكن',
+  'journey.skeletons.show': 'إظهار الاقتراحات',
+  'journey.skeletons.hide': 'إخفاء الاقتراحات',
 
   // Journey — Invite
   'journey.invite.role': 'الدور',

--- a/client/src/i18n/translations/ar.ts
+++ b/client/src/i18n/translations/ar.ts
@@ -1569,6 +1569,7 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
 
   // Journey Entry Editor
   'journey.editor.uploadPhotos': 'رفع صور',
+  'journey.editor.uploading': '...جارٍ الرفع',
   'journey.editor.fromGallery': 'من المعرض',
   'journey.editor.addAnother': 'إضافة آخر',
   'journey.editor.makeFirst': 'جعله الأول',

--- a/client/src/i18n/translations/ar.ts
+++ b/client/src/i18n/translations/ar.ts
@@ -5,6 +5,8 @@ const ar: Record<string, string | { name: string; category: string }[]> = {
 
   // Common
   'common.save': 'حفظ',
+  'common.showMore': 'عرض المزيد',
+  'common.showLess': 'عرض أقل',
   'common.cancel': 'إلغاء',
   'common.delete': 'حذف',
   'common.edit': 'تعديل',

--- a/client/src/i18n/translations/br.ts
+++ b/client/src/i18n/translations/br.ts
@@ -1895,6 +1895,8 @@ const br: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Entradas',
   'journey.stats.photos': 'Fotos',
   'journey.stats.places': 'Lugares',
+  'journey.skeletons.show': 'Mostrar sugestões',
+  'journey.skeletons.hide': 'Ocultar sugestões',
   'journey.verdict.lovedIt': 'Adorei',
   'journey.verdict.couldBeBetter': 'Poderia ser melhor',
   'journey.synced.places': 'lugares',

--- a/client/src/i18n/translations/br.ts
+++ b/client/src/i18n/translations/br.ts
@@ -1902,6 +1902,7 @@ const br: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'lugares',
   'journey.synced.synced': 'sincronizado',
   'journey.editor.uploadPhotos': 'Enviar fotos',
+  'journey.editor.uploading': 'Enviando...',
   'journey.editor.fromGallery': 'Da galeria',
   'journey.editor.allPhotosAdded': 'Todas as fotos já foram adicionadas',
   'journey.editor.writeStory': 'Escreva sua história...',

--- a/client/src/i18n/translations/br.ts
+++ b/client/src/i18n/translations/br.ts
@@ -1,6 +1,8 @@
 const br: Record<string, string | { name: string; category: string }[]> = {
   // Common
   'common.save': 'Salvar',
+  'common.showMore': 'Mostrar mais',
+  'common.showLess': 'Mostrar menos',
   'common.cancel': 'Cancelar',
   'common.delete': 'Excluir',
   'common.edit': 'Editar',

--- a/client/src/i18n/translations/cs.ts
+++ b/client/src/i18n/translations/cs.ts
@@ -1900,6 +1900,8 @@ const cs: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Záznamy',
   'journey.stats.photos': 'Fotky',
   'journey.stats.places': 'Místa',
+  'journey.skeletons.show': 'Zobrazit návrhy',
+  'journey.skeletons.hide': 'Skrýt návrhy',
   'journey.verdict.lovedIt': 'Skvělé',
   'journey.verdict.couldBeBetter': 'Mohlo by být lepší',
   'journey.synced.places': 'místa',

--- a/client/src/i18n/translations/cs.ts
+++ b/client/src/i18n/translations/cs.ts
@@ -1907,6 +1907,7 @@ const cs: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'místa',
   'journey.synced.synced': 'synchronizováno',
   'journey.editor.uploadPhotos': 'Nahrát fotky',
+  'journey.editor.uploading': 'Nahrávání...',
   'journey.editor.fromGallery': 'Z galerie',
   'journey.editor.allPhotosAdded': 'Všechny fotky již přidány',
   'journey.editor.writeStory': 'Napište svůj příběh...',

--- a/client/src/i18n/translations/cs.ts
+++ b/client/src/i18n/translations/cs.ts
@@ -1,6 +1,8 @@
 const cs: Record<string, string | { name: string; category: string }[]> = {
   // Společné (Common)
   'common.save': 'Uložit',
+  'common.showMore': 'Zobrazit více',
+  'common.showLess': 'Zobrazit méně',
   'common.cancel': 'Zrušit',
   'common.delete': 'Smazat',
   'common.edit': 'Upravit',

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -1901,6 +1901,8 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Einträge',
   'journey.stats.photos': 'Fotos',
   'journey.stats.places': 'Orte',
+  'journey.skeletons.show': 'Vorschläge anzeigen',
+  'journey.skeletons.hide': 'Vorschläge ausblenden',
   'journey.verdict.lovedIt': 'Toll',
   'journey.verdict.couldBeBetter': 'Verbesserungswürdig',
   'journey.synced.places': 'Orte',

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -1908,6 +1908,7 @@ const de: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'Orte',
   'journey.synced.synced': 'synchronisiert',
   'journey.editor.uploadPhotos': 'Fotos hochladen',
+  'journey.editor.uploading': 'Hochladen...',
   'journey.editor.fromGallery': 'Aus Galerie',
   'journey.editor.allPhotosAdded': 'Alle Fotos bereits hinzugefügt',
   'journey.editor.writeStory': 'Erzähle deine Geschichte...',

--- a/client/src/i18n/translations/de.ts
+++ b/client/src/i18n/translations/de.ts
@@ -1,6 +1,8 @@
 const de: Record<string, string | { name: string; category: string }[]> = {
   // Allgemein
   'common.save': 'Speichern',
+  'common.showMore': 'Mehr anzeigen',
+  'common.showLess': 'Weniger anzeigen',
   'common.cancel': 'Abbrechen',
   'common.delete': 'Löschen',
   'common.edit': 'Bearbeiten',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -1906,6 +1906,8 @@ const en: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Entries',
   'journey.stats.photos': 'Photos',
   'journey.stats.places': 'Places',
+  'journey.skeletons.show': 'Show suggestions',
+  'journey.skeletons.hide': 'Hide suggestions',
 
   // Journey Detail — Verdict
   'journey.verdict.lovedIt': 'Loved it',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -1919,6 +1919,7 @@ const en: Record<string, string | { name: string; category: string }[]> = {
 
   // Journey Entry Editor
   'journey.editor.uploadPhotos': 'Upload photos',
+  'journey.editor.uploading': 'Uploading...',
   'journey.editor.fromGallery': 'From Gallery',
   'journey.editor.allPhotosAdded': 'All photos already added',
   'journey.editor.writeStory': 'Write your story...',

--- a/client/src/i18n/translations/en.ts
+++ b/client/src/i18n/translations/en.ts
@@ -1,6 +1,8 @@
 const en: Record<string, string | { name: string; category: string }[]> = {
   // Common
   'common.save': 'Save',
+  'common.showMore': 'Show more',
+  'common.showLess': 'Show less',
   'common.cancel': 'Cancel',
   'common.delete': 'Delete',
   'common.edit': 'Edit',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -1902,6 +1902,8 @@ const es: Record<string, string> = {
   'journey.stats.entries': 'Entradas',
   'journey.stats.photos': 'Fotos',
   'journey.stats.places': 'Lugares',
+  'journey.skeletons.show': 'Mostrar sugerencias',
+  'journey.skeletons.hide': 'Ocultar sugerencias',
   'journey.verdict.lovedIt': 'Me encantó',
   'journey.verdict.couldBeBetter': 'Podría mejorar',
   'journey.synced.places': 'lugares',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -1909,6 +1909,7 @@ const es: Record<string, string> = {
   'journey.synced.places': 'lugares',
   'journey.synced.synced': 'sincronizado',
   'journey.editor.uploadPhotos': 'Subir fotos',
+  'journey.editor.uploading': 'Subiendo...',
   'journey.editor.fromGallery': 'Desde galería',
   'journey.editor.allPhotosAdded': 'Todas las fotos ya fueron añadidas',
   'journey.editor.writeStory': 'Escribe tu historia...',

--- a/client/src/i18n/translations/es.ts
+++ b/client/src/i18n/translations/es.ts
@@ -1,6 +1,8 @@
 const es: Record<string, string> = {
   // Common
   'common.save': 'Guardar',
+  'common.showMore': 'Ver más',
+  'common.showLess': 'Ver menos',
   'common.cancel': 'Cancelar',
   'common.delete': 'Eliminar',
   'common.edit': 'Editar',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -1896,6 +1896,8 @@ const fr: Record<string, string> = {
   'journey.stats.entries': 'Entrées',
   'journey.stats.photos': 'Photos',
   'journey.stats.places': 'Lieux',
+  'journey.skeletons.show': 'Afficher les suggestions',
+  'journey.skeletons.hide': 'Masquer les suggestions',
   'journey.verdict.lovedIt': 'Adoré',
   'journey.verdict.couldBeBetter': 'Pourrait être mieux',
   'journey.synced.places': 'lieux',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -1903,6 +1903,7 @@ const fr: Record<string, string> = {
   'journey.synced.places': 'lieux',
   'journey.synced.synced': 'synchronisé',
   'journey.editor.uploadPhotos': 'Téléverser des photos',
+  'journey.editor.uploading': 'Envoi...',
   'journey.editor.fromGallery': 'Depuis la galerie',
   'journey.editor.allPhotosAdded': 'Toutes les photos ont déjà été ajoutées',
   'journey.editor.writeStory': 'Écrivez votre histoire...',

--- a/client/src/i18n/translations/fr.ts
+++ b/client/src/i18n/translations/fr.ts
@@ -1,6 +1,8 @@
 const fr: Record<string, string> = {
   // Common
   'common.save': 'Enregistrer',
+  'common.showMore': 'Voir plus',
+  'common.showLess': 'Voir moins',
   'common.cancel': 'Annuler',
   'common.delete': 'Supprimer',
   'common.edit': 'Modifier',

--- a/client/src/i18n/translations/hu.ts
+++ b/client/src/i18n/translations/hu.ts
@@ -1897,6 +1897,8 @@ const hu: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Bejegyzések',
   'journey.stats.photos': 'Fotók',
   'journey.stats.places': 'Helyszínek',
+  'journey.skeletons.show': 'Javaslatok megjelenítése',
+  'journey.skeletons.hide': 'Javaslatok elrejtése',
   'journey.verdict.lovedIt': 'Imádtam',
   'journey.verdict.couldBeBetter': 'Lehetne jobb',
   'journey.synced.places': 'helyszín',

--- a/client/src/i18n/translations/hu.ts
+++ b/client/src/i18n/translations/hu.ts
@@ -1904,6 +1904,7 @@ const hu: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'helyszín',
   'journey.synced.synced': 'szinkronizálva',
   'journey.editor.uploadPhotos': 'Fotók feltöltése',
+  'journey.editor.uploading': 'Feltöltés...',
   'journey.editor.fromGallery': 'Galériából',
   'journey.editor.allPhotosAdded': 'Minden fotó már hozzáadva',
   'journey.editor.writeStory': 'Írd meg a történeted...',

--- a/client/src/i18n/translations/hu.ts
+++ b/client/src/i18n/translations/hu.ts
@@ -1,6 +1,8 @@
 const hu: Record<string, string | { name: string; category: string }[]> = {
   // Általános
   'common.save': 'Mentés',
+  'common.showMore': 'Továbbiak',
+  'common.showLess': 'Kevesebb',
   'common.cancel': 'Mégse',
   'common.delete': 'Törlés',
   'common.edit': 'Szerkesztés',

--- a/client/src/i18n/translations/it.ts
+++ b/client/src/i18n/translations/it.ts
@@ -1897,6 +1897,8 @@ const it: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Voci',
   'journey.stats.photos': 'Foto',
   'journey.stats.places': 'Luoghi',
+  'journey.skeletons.show': 'Mostra suggerimenti',
+  'journey.skeletons.hide': 'Nascondi suggerimenti',
   'journey.verdict.lovedIt': 'Adorato',
   'journey.verdict.couldBeBetter': 'Potrebbe essere meglio',
   'journey.synced.places': 'luoghi',

--- a/client/src/i18n/translations/it.ts
+++ b/client/src/i18n/translations/it.ts
@@ -1904,6 +1904,7 @@ const it: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'luoghi',
   'journey.synced.synced': 'sincronizzato',
   'journey.editor.uploadPhotos': 'Carica foto',
+  'journey.editor.uploading': 'Caricamento...',
   'journey.editor.fromGallery': 'Dalla galleria',
   'journey.editor.allPhotosAdded': 'Tutte le foto sono già state aggiunte',
   'journey.editor.writeStory': 'Scrivi la tua storia...',

--- a/client/src/i18n/translations/it.ts
+++ b/client/src/i18n/translations/it.ts
@@ -1,6 +1,8 @@
 const it: Record<string, string | { name: string; category: string }[]> = {
   // Common
   'common.save': 'Salva',
+  'common.showMore': 'Mostra di più',
+  'common.showLess': 'Mostra meno',
   'common.cancel': 'Annulla',
   'common.delete': 'Elimina',
   'common.edit': 'Modifica',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -1896,6 +1896,8 @@ const nl: Record<string, string> = {
   'journey.stats.entries': 'Vermeldingen',
   'journey.stats.photos': 'Foto\'s',
   'journey.stats.places': 'Plaatsen',
+  'journey.skeletons.show': 'Suggesties tonen',
+  'journey.skeletons.hide': 'Suggesties verbergen',
   'journey.verdict.lovedIt': 'Geweldig',
   'journey.verdict.couldBeBetter': 'Kan beter',
   'journey.synced.places': 'plaatsen',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -1903,6 +1903,7 @@ const nl: Record<string, string> = {
   'journey.synced.places': 'plaatsen',
   'journey.synced.synced': 'gesynchroniseerd',
   'journey.editor.uploadPhotos': 'Foto\'s uploaden',
+  'journey.editor.uploading': 'Uploaden...',
   'journey.editor.fromGallery': 'Uit galerij',
   'journey.editor.allPhotosAdded': 'Alle foto\'s al toegevoegd',
   'journey.editor.writeStory': 'Schrijf je verhaal...',

--- a/client/src/i18n/translations/nl.ts
+++ b/client/src/i18n/translations/nl.ts
@@ -1,6 +1,8 @@
 const nl: Record<string, string> = {
   // Common
   'common.save': 'Opslaan',
+  'common.showMore': 'Meer tonen',
+  'common.showLess': 'Minder tonen',
   'common.cancel': 'Annuleren',
   'common.delete': 'Verwijderen',
   'common.edit': 'Bewerken',

--- a/client/src/i18n/translations/pl.ts
+++ b/client/src/i18n/translations/pl.ts
@@ -1889,6 +1889,8 @@ const pl: Record<string, string | { name: string; category: string }[]> = {
   'journey.stats.entries': 'Wpisy',
   'journey.stats.photos': 'Zdjęcia',
   'journey.stats.places': 'Miejsca',
+  'journey.skeletons.show': 'Pokaż sugestie',
+  'journey.skeletons.hide': 'Ukryj sugestie',
   'journey.verdict.lovedIt': 'Świetne',
   'journey.verdict.couldBeBetter': 'Mogłoby być lepiej',
   'journey.synced.places': 'miejsca',

--- a/client/src/i18n/translations/pl.ts
+++ b/client/src/i18n/translations/pl.ts
@@ -1896,6 +1896,7 @@ const pl: Record<string, string | { name: string; category: string }[]> = {
   'journey.synced.places': 'miejsca',
   'journey.synced.synced': 'zsynchronizowane',
   'journey.editor.uploadPhotos': 'Prześlij zdjęcia',
+  'journey.editor.uploading': 'Przesyłanie...',
   'journey.editor.fromGallery': 'Z galerii',
   'journey.editor.allPhotosAdded': 'Wszystkie zdjęcia już dodane',
   'journey.editor.writeStory': 'Napisz swoją historię...',

--- a/client/src/i18n/translations/pl.ts
+++ b/client/src/i18n/translations/pl.ts
@@ -1,6 +1,8 @@
 const pl: Record<string, string | { name: string; category: string }[]> = {
   // Common
   'common.save': 'Zapisz',
+  'common.showMore': 'Pokaż więcej',
+  'common.showLess': 'Pokaż mniej',
   'common.cancel': 'Anuluj',
   'common.delete': 'Usuń',
   'common.edit': 'Edytuj',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -1896,6 +1896,8 @@ const ru: Record<string, string> = {
   'journey.stats.entries': 'Записей',
   'journey.stats.photos': 'Фото',
   'journey.stats.places': 'Мест',
+  'journey.skeletons.show': 'Показать предложения',
+  'journey.skeletons.hide': 'Скрыть предложения',
   'journey.verdict.lovedIt': 'Понравилось',
   'journey.verdict.couldBeBetter': 'Могло быть лучше',
   'journey.synced.places': 'мест',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -1903,6 +1903,7 @@ const ru: Record<string, string> = {
   'journey.synced.places': 'мест',
   'journey.synced.synced': 'синхронизировано',
   'journey.editor.uploadPhotos': 'Загрузить фото',
+  'journey.editor.uploading': 'Загрузка...',
   'journey.editor.fromGallery': 'Из галереи',
   'journey.editor.allPhotosAdded': 'Все фото уже добавлены',
   'journey.editor.writeStory': 'Напишите свою историю...',

--- a/client/src/i18n/translations/ru.ts
+++ b/client/src/i18n/translations/ru.ts
@@ -1,6 +1,8 @@
 const ru: Record<string, string> = {
   // Common
   'common.save': 'Сохранить',
+  'common.showMore': 'Показать больше',
+  'common.showLess': 'Показать меньше',
   'common.cancel': 'Отмена',
   'common.delete': 'Удалить',
   'common.edit': 'Редактировать',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -1896,6 +1896,8 @@ const zh: Record<string, string> = {
   'journey.stats.entries': '条目',
   'journey.stats.photos': '照片',
   'journey.stats.places': '地点',
+  'journey.skeletons.show': '显示建议',
+  'journey.skeletons.hide': '隐藏建议',
   'journey.verdict.lovedIt': '非常喜欢',
   'journey.verdict.couldBeBetter': '有待改进',
   'journey.synced.places': '个地点',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -1903,6 +1903,7 @@ const zh: Record<string, string> = {
   'journey.synced.places': '个地点',
   'journey.synced.synced': '已同步',
   'journey.editor.uploadPhotos': '上传照片',
+  'journey.editor.uploading': '上传中...',
   'journey.editor.fromGallery': '从相册',
   'journey.editor.allPhotosAdded': '所有照片已添加',
   'journey.editor.writeStory': '写下你的故事...',

--- a/client/src/i18n/translations/zh.ts
+++ b/client/src/i18n/translations/zh.ts
@@ -1,6 +1,8 @@
 const zh: Record<string, string> = {
   // Common
   'common.save': '保存',
+  'common.showMore': '显示更多',
+  'common.showLess': '收起',
   'common.cancel': '取消',
   'common.delete': '删除',
   'common.edit': '编辑',

--- a/client/src/i18n/translations/zhTw.ts
+++ b/client/src/i18n/translations/zhTw.ts
@@ -1856,6 +1856,8 @@ const zhTw: Record<string, string> = {
   'journey.stats.entries': '條目',
   'journey.stats.photos': '照片',
   'journey.stats.places': '地點',
+  'journey.skeletons.show': '顯示建議',
+  'journey.skeletons.hide': '隱藏建議',
   'journey.verdict.lovedIt': '非常喜歡',
   'journey.verdict.couldBeBetter': '有待改進',
   'journey.synced.places': '個地點',

--- a/client/src/i18n/translations/zhTw.ts
+++ b/client/src/i18n/translations/zhTw.ts
@@ -1863,6 +1863,7 @@ const zhTw: Record<string, string> = {
   'journey.synced.places': '個地點',
   'journey.synced.synced': '已同步',
   'journey.editor.uploadPhotos': '上傳照片',
+  'journey.editor.uploading': '上傳中...',
   'journey.editor.fromGallery': '從相簿',
   'journey.editor.allPhotosAdded': '所有照片已新增',
   'journey.editor.writeStory': '寫下你的故事...',

--- a/client/src/i18n/translations/zhTw.ts
+++ b/client/src/i18n/translations/zhTw.ts
@@ -1,6 +1,8 @@
 const zhTw: Record<string, string> = {
   // Common
   'common.save': '儲存',
+  'common.showMore': '顯示更多',
+  'common.showLess': '收起',
   'common.cancel': '取消',
   'common.delete': '刪除',
   'common.edit': '編輯',

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -296,8 +296,9 @@ export default function AtlasPage(): React.ReactElement {
       updateWhenIdle: false,
       tileSize: 256,
       zoomOffset: 0,
-      crossOrigin: true
-    }).addTo(map)
+      crossOrigin: true,
+      referrerPolicy: 'strict-origin-when-cross-origin',
+    } as any).addTo(map)
 
     // Preload adjacent zoom level tiles
     L.tileLayer(tileUrl, {
@@ -306,6 +307,7 @@ export default function AtlasPage(): React.ReactElement {
       opacity: 0,
       tileSize: 256,
       crossOrigin: true,
+      referrerPolicy: 'strict-origin-when-cross-origin',
     }).addTo(map)
 
     // Custom pane for region layer — above overlay (z-index 400)

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -18,7 +18,7 @@ import {
   Clock, Package, Image, ChevronRight,
   UserPlus, Plus, Minus, Calendar, Camera, BookOpen, X, Check, ImagePlus, Trash2, Pencil,
   Laugh, Smile, Meh, Annoyed, Frown,
-  Sun, CloudSun, Cloud, CloudRain, CloudLightning, Snowflake, ChevronDown,
+  Sun, CloudSun, Cloud, CloudRain, CloudLightning, Snowflake, ChevronDown, Eye, EyeOff,
 } from 'lucide-react'
 import type { JourneyEntry, JourneyPhoto, JourneyDetail } from '../store/journeyStore'
 
@@ -92,10 +92,15 @@ export default function JourneyDetailPage() {
   const [showAddTrip, setShowAddTrip] = useState(false)
   const [unlinkTrip, setUnlinkTrip] = useState<{ trip_id: number; title: string } | null>(null)
   const [showSettings, setShowSettings] = useState(false)
+  const [hideSkeletons, setHideSkeletons] = useState(false)
 
   useEffect(() => {
     if (id) loadJourney(Number(id)).catch(() => {})
   }, [id])
+
+  useEffect(() => {
+    if (current?.hide_skeletons !== undefined) setHideSkeletons(current.hide_skeletons)
+  }, [current?.hide_skeletons])
 
   useEffect(() => {
     if (notFound) {
@@ -193,7 +198,7 @@ export default function JourneyDetailPage() {
     )
   }
 
-  const timelineEntries = current.entries.filter(e => e.title !== 'Gallery' && e.title !== '[Trip Photos]')
+  const timelineEntries = current.entries.filter(e => e.title !== 'Gallery' && e.title !== '[Trip Photos]' && (!hideSkeletons || e.type !== 'skeleton'))
   const dayGroups = groupByDate(timelineEntries)
   const sortedDates = [...dayGroups.keys()].sort()
 
@@ -243,7 +248,21 @@ export default function JourneyDetailPage() {
                   </button>
                   <div className="flex items-center gap-1.5">
                     <button onClick={() => { import('../components/PDF/JourneyBookPDF').then(m => m.downloadJourneyBookPDF(current)) }} className="w-[34px] h-[34px] rounded-lg bg-white/15 backdrop-blur flex items-center justify-center hover:bg-white/25"><Download size={14} /></button>
-                    <button onClick={() => setShowSettings(true)} className="w-[34px] h-[34px] rounded-lg bg-white/15 backdrop-blur flex items-center justify-center hover:bg-white/25"><Share2 size={14} /></button>
+                    <div className="relative group">
+                      <button
+                        onClick={async () => {
+                          const next = !hideSkeletons
+                          setHideSkeletons(next)
+                          await journeyApi.updatePreferences(current.id, { hide_skeletons: next })
+                        }}
+                        className={`w-[34px] h-[34px] rounded-lg backdrop-blur flex items-center justify-center ${hideSkeletons ? 'bg-white/30' : 'bg-white/15 hover:bg-white/25'}`}
+                      >
+                        {hideSkeletons ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </button>
+                      <span className="absolute top-full mt-2 left-1/2 -translate-x-1/2 px-2 py-1 rounded-md bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 text-[11px] font-medium whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity">
+                        {hideSkeletons ? t('journey.skeletons.show') : t('journey.skeletons.hide')}
+                      </span>
+                    </div>
                     <button onClick={() => setShowSettings(true)} className="w-[34px] h-[34px] rounded-lg bg-white/15 backdrop-blur flex items-center justify-center hover:bg-white/25"><MoreHorizontal size={14} /></button>
                   </div>
                 </div>

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -1486,8 +1486,12 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
         const assets = data.assets || []
         setPhotos(prev => append ? [...prev, ...assets] : assets)
         setHasMore(!!data.hasMore)
+      } else {
+        setHasMore(false)
       }
-    } catch (e: any) { if (e.name !== 'AbortError') {} }
+    } catch (e: any) {
+      if (e.name !== 'AbortError') setHasMore(false)
+    }
     if (!signal.aborted) { setLoading(false); setLoadingMore(false) }
   }
 
@@ -1500,6 +1504,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
     const signal = cancelPending()
     setLoading(true)
     setPhotos([])
+    setHasMore(false)
     try {
       const res = await fetch(`/api/integrations/memories/${provider}/albums/${albumId}/photos`, { credentials: 'include', signal })
       if (res.ok) setPhotos((await res.json()).assets || [])
@@ -1773,7 +1778,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
                 )
               })}
               {/* Infinite scroll trigger */}
-              {hasMore && <ScrollTrigger onVisible={loadMorePhotos} loading={loadingMore} />}
+              {hasMore && !selectedAlbum && <ScrollTrigger onVisible={loadMorePhotos} loading={loadingMore} />}
             </div>
           )}
         </div>

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -772,6 +772,7 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
   const [showPicker, setShowPicker] = useState(false)
   const [pickerProvider, setPickerProvider] = useState<string | null>(null)
   const [availableProviders, setAvailableProviders] = useState<{ id: string; name: string }[]>([])
+  const [galleryUploading, setGalleryUploading] = useState(false)
   const toast = useToast()
 
   // check which providers are enabled AND connected for the current user
@@ -816,27 +817,28 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
   const handleGalleryUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     if (!files?.length) return
-    // find existing "Gallery" entry or create one
-    let galleryEntry = entries.find(e => e.title === 'Gallery' && e.type === 'entry')
-    let entryId = galleryEntry?.id
-    if (!entryId) {
-      try {
+    setGalleryUploading(true)
+    try {
+      // find existing "Gallery" entry or create one
+      let galleryEntry = entries.find(e => e.title === 'Gallery' && e.type === 'entry')
+      let entryId = galleryEntry?.id
+      if (!entryId) {
         const entry = await journeyApi.createEntry(journeyId, {
           title: t('journey.share.gallery'),
           entry_date: new Date().toISOString().split('T')[0],
           type: 'entry',
         })
         entryId = entry.id
-      } catch { return }
-    }
-    const formData = new FormData()
-    for (const f of files) formData.append('photos', f)
-    try {
+      }
+      const formData = new FormData()
+      for (const f of files) formData.append('photos', f)
       await journeyApi.uploadPhotos(entryId, formData)
       toast.success(t('journey.photosUploaded', { count: files.length }))
       onRefresh()
     } catch {
       toast.error(t('journey.settings.coverFailed'))
+    } finally {
+      setGalleryUploading(false)
     }
     e.target.value = ''
   }
@@ -874,10 +876,14 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
         <div className="flex items-center gap-2">
           <button
             onClick={() => galleryFileRef.current?.click()}
-            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-[11px] font-medium hover:bg-zinc-800 dark:hover:bg-zinc-100"
+            disabled={galleryUploading}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-[11px] font-medium hover:bg-zinc-800 dark:hover:bg-zinc-100 disabled:opacity-50"
           >
-            <Plus size={12} />
-            {t('common.upload')}
+            {galleryUploading ? (
+              <><div className="w-3 h-3 border-2 border-white/30 dark:border-zinc-900/30 border-t-white dark:border-t-zinc-900 rounded-full animate-spin" /> {t('journey.editor.uploading')}</>
+            ) : (
+              <><Plus size={12} /> {t('common.upload')}</>
+            )}
           </button>
           {availableProviders.map(p => (
             <button
@@ -1918,6 +1924,7 @@ function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, onClose, onSa
   const [pros, setPros] = useState<string[]>(entry.pros_cons?.pros?.length ? entry.pros_cons.pros : [''])
   const [cons, setCons] = useState<string[]>(entry.pros_cons?.cons?.length ? entry.pros_cons.cons : [''])
   const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
   const [photos, setPhotos] = useState<JourneyPhoto[]>(entry.photos || [])
   const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [pendingLinkIds, setPendingLinkIds] = useState<number[]>([])
@@ -1966,10 +1973,15 @@ function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, onClose, onSa
       // queue files for upload after save
       setPendingFiles(prev => [...prev, ...Array.from(files)])
     } else {
-      const formData = new FormData()
-      for (const f of files) formData.append('photos', f)
-      const newPhotos = await onUploadPhotos(entry.id, formData)
-      if (newPhotos?.length) setPhotos(prev => [...prev, ...newPhotos])
+      setUploading(true)
+      try {
+        const formData = new FormData()
+        for (const f of files) formData.append('photos', f)
+        const newPhotos = await onUploadPhotos(entry.id, formData)
+        if (newPhotos?.length) setPhotos(prev => [...prev, ...newPhotos])
+      } finally {
+        setUploading(false)
+      }
     }
   }
 
@@ -1997,9 +2009,14 @@ function EntryEditor({ entry, journeyId, tripDates, galleryPhotos, onClose, onSa
             <div className="flex gap-2">
               <button
                 onClick={() => fileRef.current?.click()}
-                className="flex-1 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg py-4 text-[12px] text-zinc-500 hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center justify-center gap-1.5"
+                disabled={uploading}
+                className="flex-1 border border-dashed border-zinc-200 dark:border-zinc-700 rounded-lg py-4 text-[12px] text-zinc-500 hover:border-zinc-400 dark:hover:border-zinc-500 hover:bg-zinc-50 dark:hover:bg-zinc-800 flex items-center justify-center gap-1.5 disabled:opacity-50"
               >
-                <Plus size={13} /> {t('journey.editor.uploadPhotos')}
+                {uploading ? (
+                  <><div className="w-3.5 h-3.5 border-2 border-zinc-300 border-t-zinc-600 rounded-full animate-spin" /> {t('journey.editor.uploading')}</>
+                ) : (
+                  <><Plus size={13} /> {t('journey.editor.uploadPhotos')}</>
+                )}
               </button>
               {galleryPhotos.length > 0 && (
                 <button

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -2733,8 +2733,8 @@ function JourneySettingsDialog({ journey, onClose, onSaved, onOpenInvite }: {
   }
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center p-5" style={{ background: 'rgba(9,9,11,0.6)', backdropFilter: 'blur(6px)' }}>
-      <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.2)] max-w-[480px] w-full max-h-[90vh] flex flex-col overflow-hidden">
+    <div className="fixed inset-0 z-[200] flex items-end md:items-center justify-center md:p-5 overscroll-none" style={{ background: 'rgba(9,9,11,0.6)', backdropFilter: 'blur(6px)' }} onClick={onClose} onTouchMove={e => { if (e.target === e.currentTarget) e.preventDefault() }}>
+      <div className="bg-white dark:bg-zinc-900 rounded-t-2xl md:rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.2)] max-w-[480px] w-full max-h-[85vh] md:max-h-[90vh] flex flex-col overflow-hidden pb-safe" onClick={e => e.stopPropagation()}>
 
         <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-700">
           <h2 className="text-[16px] font-bold text-zinc-900 dark:text-white">{t('journey.settings.title')}</h2>
@@ -2743,7 +2743,7 @@ function JourneySettingsDialog({ journey, onClose, onSaved, onOpenInvite }: {
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-5">
+        <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-5 flex flex-col gap-5">
           {/* Cover Image */}
           <div>
             <label className="text-[10px] font-semibold tracking-[0.12em] uppercase text-zinc-500 block mb-2">{t('journey.settings.coverImage')}</label>
@@ -2846,7 +2846,7 @@ function JourneySettingsDialog({ journey, onClose, onSaved, onOpenInvite }: {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center gap-2 px-6 py-4 border-t border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
+        <div className="flex items-center gap-2 px-6 py-4 pb-6 md:pb-4 border-t border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
           <button
             onClick={() => setShowDeleteConfirm(true)}
             className="flex items-center gap-1.5 text-[12px] font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg px-2.5 py-2 mr-auto"

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -928,11 +928,11 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
               >
                 <X size={12} />
               </button>
-              {photo.provider !== 'local' && (
+              {photo.provider && photo.provider !== 'local' && (
                 <div className="absolute top-1.5 left-1.5">
                   <span className="text-[8px] font-medium px-1.5 py-0.5 rounded-full bg-black/70 backdrop-blur text-white flex items-center gap-1">
                     <RefreshCw size={7} />
-                    {photo.provider === 'immich' ? 'Immich' : 'Synology'}
+                    {photo.provider === 'immich' ? 'Immich' : photo.provider === 'synology' ? 'Synology' : photo.provider}
                   </span>
                 </div>
               )}

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -992,6 +992,7 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
 // ── Expandable Story ─────────────────────────────────────────────────────
 
 function ExpandableStory({ story }: { story: string }) {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [clamped, setClamped] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -1017,16 +1018,24 @@ function ExpandableStory({ story }: { story: string }) {
         onClick={() => { if (clamped || expanded) setExpanded(e => !e) }}
         className={`text-[13px] text-zinc-700 dark:text-zinc-300 leading-relaxed ${
           expanded ? '' : 'line-clamp-3 md:line-clamp-[9]'
-        } ${clamped || expanded ? 'cursor-pointer md:cursor-auto' : ''}`}
+        } ${clamped || expanded ? 'cursor-pointer' : ''}`}
       >
         <JournalBody text={story} />
       </div>
       {clamped && !expanded && (
         <button
           onClick={() => setExpanded(true)}
-          className="md:hidden mt-2 inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-[10px] font-medium text-zinc-500 dark:text-zinc-400 active:scale-95 transition-transform"
+          className="mt-2 inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-[10px] font-medium text-zinc-500 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 active:scale-95 transition-all"
         >
-          Read more <ChevronRight size={10} />
+          {t('common.showMore')} <ChevronRight size={10} />
+        </button>
+      )}
+      {expanded && (
+        <button
+          onClick={() => setExpanded(false)}
+          className="mt-2 inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-[10px] font-medium text-zinc-500 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 active:scale-95 transition-all"
+        >
+          {t('common.showLess')} <ChevronRight size={10} className="rotate-[-90deg]" />
         </button>
       )}
     </div>

--- a/client/src/store/journeyStore.ts
+++ b/client/src/store/journeyStore.ts
@@ -82,6 +82,7 @@ export interface JourneyDetail extends Journey {
   trips: JourneyTrip[]
   contributors: JourneyContributor[]
   stats: { entries: number; photos: number; cities: number }
+  hide_skeletons?: boolean
 }
 
 interface JourneyState {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -1574,6 +1574,10 @@ function runMigrations(db: Database.Database): void {
         db.exec('CREATE INDEX IF NOT EXISTS idx_journey_photos_photo ON journey_photos(photo_id)');
       }
     },
+    // Migration 99: hide_skeletons per-user setting on journey_contributors
+    () => {
+      try { db.exec('ALTER TABLE journey_contributors ADD COLUMN hide_skeletons INTEGER NOT NULL DEFAULT 0'); } catch {}
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/routes/journey.ts
+++ b/server/src/routes/journey.ts
@@ -279,6 +279,15 @@ router.delete('/:id/contributors/:userId', authenticate, (req: Request, res: Res
   res.json({ success: true });
 });
 
+// ── User Preferences ─────────────────────────────────────────────────────
+
+router.patch('/:id/preferences', authenticate, (req: Request, res: Response) => {
+  const authReq = req as AuthRequest;
+  const result = svc.updateJourneyPreferences(Number(req.params.id), authReq.user.id, req.body);
+  if (!result) return res.status(403).json({ error: 'Not allowed' });
+  res.json(result);
+});
+
 // ── Share Link ────────────────────────────────────────────────────────────
 
 router.get('/:id/share-link', authenticate, (req: Request, res: Response) => {

--- a/server/src/services/journeyService.ts
+++ b/server/src/services/journeyService.ts
@@ -161,12 +161,17 @@ export function getJourneyFull(journeyId: number, userId: number) {
   const photoCount = photos.length;
   const cities = [...new Set(entries.map(e => e.location_name).filter(Boolean))];
 
+  const userPrefs = db.prepare(
+    'SELECT hide_skeletons FROM journey_contributors WHERE journey_id = ? AND user_id = ?'
+  ).get(journeyId, userId) as { hide_skeletons: number } | undefined;
+
   return {
     ...journey,
     entries: enrichedEntries,
     trips,
     contributors,
     stats: { entries: entryCount, photos: photoCount, cities: cities.length },
+    hide_skeletons: !!(userPrefs?.hide_skeletons),
   };
 }
 
@@ -195,6 +200,19 @@ export function updateJourney(journeyId: number, userId: number, data: Partial<{
   values.push(journeyId);
   db.prepare(`UPDATE journeys SET ${fields.join(', ')} WHERE id = ?`).run(...values);
   return db.prepare('SELECT * FROM journeys WHERE id = ?').get(journeyId) as Journey;
+}
+
+export function updateJourneyPreferences(journeyId: number, userId: number, data: { hide_skeletons?: boolean }) {
+  if (!canAccessJourney(journeyId, userId)) return null;
+  if (data.hide_skeletons !== undefined) {
+    db.prepare(
+      'UPDATE journey_contributors SET hide_skeletons = ? WHERE journey_id = ? AND user_id = ?'
+    ).run(data.hide_skeletons ? 1 : 0, journeyId, userId);
+  }
+  const row = db.prepare(
+    'SELECT hide_skeletons FROM journey_contributors WHERE journey_id = ? AND user_id = ?'
+  ).get(journeyId, userId) as { hide_skeletons: number };
+  return { hide_skeletons: !!row.hide_skeletons };
 }
 
 export function deleteJourney(journeyId: number, userId: number): boolean {
@@ -567,7 +585,20 @@ export function deleteEntry(entryId: number, userId: number, sid?: string): bool
 
   // delete photos along with the entry — no more orphan Gallery entries
   db.prepare('DELETE FROM journey_photos WHERE entry_id = ?').run(entryId);
-  db.prepare('DELETE FROM journey_entries WHERE id = ?').run(entryId);
+
+  if (entry.source_trip_id && entry.source_place_id && entry.type !== 'skeleton') {
+    // Revert filled entry back to skeleton instead of deleting
+    db.prepare(`
+      UPDATE journey_entries
+      SET type = 'skeleton', story = NULL, mood = NULL, weather = NULL, pros_cons = NULL,
+          visibility = 'private', updated_at = ?
+      WHERE id = ?
+    `).run(ts(), entryId);
+    broadcastJourneyEvent(entry.journey_id, 'journey:entry:updated', { entryId }, sid);
+  } else {
+    db.prepare('DELETE FROM journey_entries WHERE id = ?').run(entryId);
+    broadcastJourneyEvent(entry.journey_id, 'journey:entry:deleted', { entryId }, sid);
+  }
 
   // clean up any empty Gallery entries in this journey
   db.prepare(`
@@ -575,7 +606,6 @@ export function deleteEntry(entryId: number, userId: number, sid?: string): bool
     AND id NOT IN (SELECT DISTINCT entry_id FROM journey_photos)
   `).run(entry.journey_id);
 
-  broadcastJourneyEvent(entry.journey_id, 'journey:entry:deleted', { entryId }, sid);
   return true;
 }
 

--- a/server/tests/unit/services/journeyService.test.ts
+++ b/server/tests/unit/services/journeyService.test.ts
@@ -565,6 +565,46 @@ describe('deleteEntry', () => {
 
     expect(deleteEntry(entry.id, viewer.id)).toBe(false);
   });
+
+  it('JOURNEY-SVC-037b: deleting a filled skeleton reverts it back to skeleton', () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const trip = createTrip(testDb, user.id);
+    const place = createPlace(testDb, trip.id, { name: 'Tokyo Tower' });
+
+    // Create a filled entry that originated from a trip skeleton
+    const now = Date.now();
+    testDb.prepare(`
+      INSERT INTO journey_entries (journey_id, source_trip_id, source_place_id, author_id, type, title, story, mood, entry_date, location_name, visibility, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 'entry', 'Tokyo Tower', 'Amazing view!', 'amazing', '2026-03-01', 'Tokyo', 'private', 0, ?, ?)
+    `).run(journey.id, trip.id, place.id, user.id, now, now);
+    const entry = testDb.prepare('SELECT * FROM journey_entries WHERE journey_id = ? AND source_place_id = ?').get(journey.id, place.id) as any;
+
+    const result = deleteEntry(entry.id, user.id);
+    expect(result).toBe(true);
+
+    // Entry should still exist but reverted to skeleton
+    const reverted = testDb.prepare('SELECT * FROM journey_entries WHERE id = ?').get(entry.id) as any;
+    expect(reverted).toBeDefined();
+    expect(reverted.type).toBe('skeleton');
+    expect(reverted.story).toBeNull();
+    expect(reverted.mood).toBeNull();
+    expect(reverted.source_trip_id).toBe(trip.id);
+    expect(reverted.source_place_id).toBe(place.id);
+    expect(reverted.title).toBe('Tokyo Tower');
+  });
+
+  it('JOURNEY-SVC-037c: deleting an independent entry permanently removes it', () => {
+    const { user } = createUser(testDb);
+    const journey = createJourney(testDb, user.id);
+    const entry = createJourneyEntry(testDb, journey.id, user.id, { entry_date: '2026-03-01', story: 'Manual entry' });
+
+    const result = deleteEntry(entry.id, user.id);
+    expect(result).toBe(true);
+
+    const row = testDb.prepare('SELECT * FROM journey_entries WHERE id = ?').get(entry.id);
+    expect(row).toBeUndefined();
+  });
 });
 
 // -- Photos -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix #619: Deleting a filled skeleton entry now reverts it back to a skeleton instead of permanently removing it, preserving the trip place suggestion
- Add per-user "hide suggestions" toggle (Eye/EyeOff icon) in the journey detail header, stored server-side for cross-device consistency
- Add migration 99: `hide_skeletons` column on `journey_contributors`
- Fix #622: Add upload loading indicator (spinner + disabled state) for photo uploads in entry editor and gallery view
- Fix #623: Show "Show more"/"Show less" button for long journal entries on both mobile and desktop
- Fix #624: Content divider now inserts at cursor position instead of above current line
- Fix #625: Fix local photos incorrectly showing Immich/Synology provider label in gallery (null provider guard)
- Fix #626: Journey settings dialog now scrollable on mobile, bottom-sheet style, safe area padding for navbar
- Fix #629: Move memories providers (Immich, Synology) from trip addons to sub-items under the Journey global addon
- Fix #640: Add `referrerPolicy` to journey and atlas map tile layers (Stadia Maps requires referrer header for domain validation)
- Fix #644: Stop pagination on fetch error and prevent timeline photos leaking into album view