### PR TITLE
fix(atlas): add A3 fallback when ISO_A2 is invalid + cleanup

### DIFF
--- a/client/src/pages/AtlasPage.test.tsx
+++ b/client/src/pages/AtlasPage.test.tsx
@@ -127,6 +127,23 @@ const geoJsonWithFR = {
   ],
 };
 
+const geoJsonWithFranceA3Fallback = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {
+        ISO_A2: '-99',
+        ADM0_A3: 'FRA',
+        ISO_A3: 'FRA',
+        NAME: 'France',
+        ADMIN: 'France',
+      },
+      geometry: null,
+    },
+  ],
+};
+
 // ── Atlas API response fixture ────────────────────────────────────────────────
 const atlasStatsResponse = {
   countries: [{ code: 'FR', tripCount: 2, placeCount: 5, firstVisit: '2023-01-01', lastVisit: '2024-06-01' }],
@@ -1320,6 +1337,33 @@ describe('AtlasPage', () => {
 
       // XK is not in A2_TO_A3_BASE, so the geoJSON loop covers the `A2_TO_A3[a2] = a3` line
       expect(screen.getAllByText(/countries/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('FE-PAGE-ATLAS-041: country search falls back from A3 when ISO_A2 is invalid', () => {
+    it('returns France in search results when GeoJSON provides ADM0_A3 but ISO_A2 is -99', async () => {
+      vi.spyOn(global, 'fetch').mockImplementation((url) => {
+        const urlStr = String(url);
+        if (urlStr.includes('geojson') || urlStr.includes('githubusercontent')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(geoJsonWithFranceA3Fallback) } as Response);
+        }
+        return Promise.reject(new Error(`Unmocked fetch: ${urlStr}`));
+      });
+
+      const user = userEvent.setup();
+      render(<AtlasPage />);
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/search a country/i)).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByPlaceholderText(/search a country/i);
+      await user.type(searchInput, 'france');
+
+      await waitFor(() => {
+        const franceButton = screen.getAllByRole('button').find((button) => button.textContent?.includes('France'));
+        expect(franceButton).toBeTruthy();
+      });
     });
   });
 

--- a/client/src/pages/AtlasPage.test.tsx
+++ b/client/src/pages/AtlasPage.test.tsx
@@ -127,22 +127,22 @@ const geoJsonWithFR = {
   ],
 };
 
-const geoJsonWithFranceA3Fallback = {
+const makeGeoJsonWithA3Fallback = (a3: string, name: string) => ({
   type: 'FeatureCollection',
   features: [
     {
       type: 'Feature',
       properties: {
         ISO_A2: '-99',
-        ADM0_A3: 'FRA',
-        ISO_A3: 'FRA',
-        NAME: 'France',
-        ADMIN: 'France',
+        ADM0_A3: a3,
+        ISO_A3: a3,
+        NAME: name,
+        ADMIN: name,
       },
       geometry: null,
     },
   ],
-};
+});
 
 // ── Atlas API response fixture ────────────────────────────────────────────────
 const atlasStatsResponse = {
@@ -1341,11 +1341,14 @@ describe('AtlasPage', () => {
   });
 
   describe('FE-PAGE-ATLAS-041: country search falls back from A3 when ISO_A2 is invalid', () => {
-    it('returns France in search results when GeoJSON provides ADM0_A3 but ISO_A2 is -99', async () => {
+    it.each([
+      { a3: 'FRA', name: 'France', query: 'france' },
+      { a3: 'NOR', name: 'Norway', query: 'norway' },
+    ])('returns $name in search results when GeoJSON provides ADM0_A3=$a3 but ISO_A2 is -99', async ({ a3, name, query }) => {
       vi.spyOn(global, 'fetch').mockImplementation((url) => {
         const urlStr = String(url);
         if (urlStr.includes('geojson') || urlStr.includes('githubusercontent')) {
-          return Promise.resolve({ ok: true, json: () => Promise.resolve(geoJsonWithFranceA3Fallback) } as Response);
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(makeGeoJsonWithA3Fallback(a3, name)) } as Response);
         }
         return Promise.reject(new Error(`Unmocked fetch: ${urlStr}`));
       });
@@ -1358,11 +1361,11 @@ describe('AtlasPage', () => {
       });
 
       const searchInput = screen.getByPlaceholderText(/search a country/i);
-      await user.type(searchInput, 'france');
+      await user.type(searchInput, query);
 
       await waitFor(() => {
-        const franceButton = screen.getAllByRole('button').find((button) => button.textContent?.includes('France'));
-        expect(franceButton).toBeTruthy();
+        const countryButton = screen.getAllByRole('button').find((button) => button.textContent?.includes(name));
+        expect(countryButton).toBeTruthy();
       });
     });
   });

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -189,8 +189,15 @@ export default function AtlasPage(): React.ReactElement {
     const opts: { code: string; label: string }[] = []
     const seen = new Set<string>()
     for (const f of (geoData as any).features || []) {
-      const a2 = f?.properties?.ISO_A2
-      if (!a2 || a2 === '-99' || typeof a2 !== 'string' || a2.length !== 2) continue
+      let a2 = f?.properties?.ISO_A2
+      if (!a2 || a2 === '-99' || typeof a2 !== 'string' || a2.length !== 2) {
+        const a3 = f?.properties?.ADM0_A3 || f?.properties?.ISO_A3 || f?.properties?.['ISO3166-1-Alpha-3'] || null
+        if (a3 && a3 !== '-99') {
+          const a3ToA2Entry = Object.entries(A2_TO_A3).find(([, v]) => v === a3)
+          a2 = a3ToA2Entry ? a3ToA2Entry[0] : null
+        }
+      }
+      if (!a2 || typeof a2 !== 'string' || a2.length !== 2) continue
       if (seen.has(a2)) continue
       seen.add(a2)
       const label = String(resolveName(a2) || f?.properties?.NAME || f?.properties?.ADMIN || a2)

--- a/client/src/pages/AtlasPage.tsx
+++ b/client/src/pages/AtlasPage.tsx
@@ -109,10 +109,14 @@ function useCountryNames(language: string): (code: string) => string {
   return resolver
 }
 
-// Map visited country codes to ISO-3166 alpha3 (GeoJSON uses alpha3)
-// Built dynamically from GeoJSON + hardcoded fallbacks
-const A2_TO_A3_BASE: Record<string, string> = {"AF":"AFG","AL":"ALB","DZ":"DZA","AD":"AND","AO":"AGO","AG":"ATG","AR":"ARG","AM":"ARM","AU":"AUS","AT":"AUT","AZ":"AZE","BS":"BHS","BH":"BHR","BD":"BGD","BB":"BRB","BY":"BLR","BE":"BEL","BZ":"BLZ","BJ":"BEN","BT":"BTN","BO":"BOL","BA":"BIH","BW":"BWA","BR":"BRA","BN":"BRN","BG":"BGR","BF":"BFA","BI":"BDI","CV":"CPV","KH":"KHM","CM":"CMR","CA":"CAN","CF":"CAF","TD":"TCD","CL":"CHL","CN":"CHN","CO":"COL","KM":"COM","CG":"COG","CD":"COD","CR":"CRI","CI":"CIV","HR":"HRV","CU":"CUB","CY":"CYP","CZ":"CZE","DK":"DNK","DJ":"DJI","DM":"DMA","DO":"DOM","EC":"ECU","EG":"EGY","SV":"SLV","GQ":"GNQ","ER":"ERI","EE":"EST","SZ":"SWZ","ET":"ETH","FJ":"FJI","FI":"FIN","FR":"FRA","GA":"GAB","GM":"GMB","GE":"GEO","DE":"DEU","GH":"GHA","GR":"GRC","GD":"GRD","GT":"GTM","GN":"GIN","GW":"GNB","GY":"GUY","HT":"HTI","HN":"HND","HU":"HUN","IS":"ISL","IN":"IND","ID":"IDN","IR":"IRN","IQ":"IRQ","IE":"IRL","IL":"ISR","IT":"ITA","JM":"JAM","JP":"JPN","JO":"JOR","KZ":"KAZ","KE":"KEN","KI":"KIR","KP":"PRK","KR":"KOR","KW":"KWT","KG":"KGZ","LA":"LAO","LV":"LVA","LB":"LBN","LS":"LSO","LR":"LBR","LY":"LBY","LI":"LIE","LT":"LTU","LU":"LUX","MG":"MDG","MW":"MWI","MY":"MYS","MV":"MDV","ML":"MLI","MT":"MLT","MR":"MRT","MU":"MUS","MX":"MEX","MD":"MDA","MN":"MNG","ME":"MNE","MA":"MAR","MZ":"MOZ","MM":"MMR","NA":"NAM","NP":"NPL","NL":"NLD","NZ":"NZL","NI":"NIC","NE":"NER","NG":"NGA","MK":"MKD","NO":"NOR","OM":"OMN","PK":"PAK","PA":"PAN","PG":"PNG","PY":"PRY","PE":"PER","PH":"PHL","PL":"POL","PT":"PRT","QA":"QAT","RO":"ROU","RU":"RUS","RW":"RWA","SA":"SAU","SN":"SEN","RS":"SRB","SL":"SLE","SG":"SGP","SK":"SVK","SI":"SVN","SB":"SLB","SO":"SOM","ZA":"ZAF","SS":"SSD","ES":"ESP","LK":"LKA","SD":"SDN","SR":"SUR","SE":"SWE","CH":"CHE","SY":"SYR","TW":"TWN","TJ":"TJK","TZ":"TZA","TH":"THA","TL":"TLS","TG":"TGO","TT":"TTO","TN":"TUN","TR":"TUR","TM":"TKM","UG":"UGA","UA":"UKR","AE":"ARE","GB":"GBR","US":"USA","UY":"URY","UZ":"UZB","VU":"VUT","VE":"VEN","VN":"VNM","YE":"YEM","ZM":"ZMB","ZW":"ZWE"}
-let A2_TO_A3: Record<string, string> = { ...A2_TO_A3_BASE }
+// ISO-3166-1 alpha-2 → alpha-3 mapping. Two sources feed this table:
+//   1. Hardcoded entries below — REQUIRED for any country whose Natural Earth GeoJSON record
+//      has ISO_A2='-99' (e.g. France=FRA, Norway=NOR). The runtime augmentation loop
+//      (see geoData useEffect below) skips '-99' features, so those countries MUST be
+//      listed here or the atlas_country_options A3-fallback will silently fail.
+//   2. Runtime augmentation — the geoData load effect adds entries for every feature
+//      that has a valid ISO_A2, covering territories not present below.
+const A2_TO_A3: Record<string, string> = {"AF":"AFG","AL":"ALB","DZ":"DZA","AD":"AND","AO":"AGO","AG":"ATG","AR":"ARG","AM":"ARM","AU":"AUS","AT":"AUT","AZ":"AZE","BS":"BHS","BH":"BHR","BD":"BGD","BB":"BRB","BY":"BLR","BE":"BEL","BZ":"BLZ","BJ":"BEN","BT":"BTN","BO":"BOL","BA":"BIH","BW":"BWA","BR":"BRA","BN":"BRN","BG":"BGR","BF":"BFA","BI":"BDI","CV":"CPV","KH":"KHM","CM":"CMR","CA":"CAN","CF":"CAF","TD":"TCD","CL":"CHL","CN":"CHN","CO":"COL","KM":"COM","CG":"COG","CD":"COD","CR":"CRI","CI":"CIV","HR":"HRV","CU":"CUB","CY":"CYP","CZ":"CZE","DK":"DNK","DJ":"DJI","DM":"DMA","DO":"DOM","EC":"ECU","EG":"EGY","SV":"SLV","GQ":"GNQ","ER":"ERI","EE":"EST","SZ":"SWZ","ET":"ETH","FJ":"FJI","FI":"FIN","FR":"FRA","GA":"GAB","GM":"GMB","GE":"GEO","DE":"DEU","GH":"GHA","GR":"GRC","GD":"GRD","GT":"GTM","GN":"GIN","GW":"GNB","GY":"GUY","HT":"HTI","HN":"HND","HU":"HUN","IS":"ISL","IN":"IND","ID":"IDN","IR":"IRN","IQ":"IRQ","IE":"IRL","IL":"ISR","IT":"ITA","JM":"JAM","JP":"JPN","JO":"JOR","KZ":"KAZ","KE":"KEN","KI":"KIR","KP":"PRK","KR":"KOR","KW":"KWT","KG":"KGZ","LA":"LAO","LV":"LVA","LB":"LBN","LS":"LSO","LR":"LBR","LY":"LBY","LI":"LIE","LT":"LTU","LU":"LUX","MG":"MDG","MW":"MWI","MY":"MYS","MV":"MDV","ML":"MLI","MT":"MLT","MR":"MRT","MU":"MUS","MX":"MEX","MD":"MDA","MN":"MNG","ME":"MNE","MA":"MAR","MZ":"MOZ","MM":"MMR","NA":"NAM","NP":"NPL","NL":"NLD","NZ":"NZL","NI":"NIC","NE":"NER","NG":"NGA","MK":"MKD","NO":"NOR","OM":"OMN","PK":"PAK","PA":"PAN","PG":"PNG","PY":"PRY","PE":"PER","PH":"PHL","PL":"POL","PT":"PRT","QA":"QAT","RO":"ROU","RU":"RUS","RW":"RWA","SA":"SAU","SN":"SEN","RS":"SRB","SL":"SLE","SG":"SGP","SK":"SVK","SI":"SVN","SB":"SLB","SO":"SOM","ZA":"ZAF","SS":"SSD","ES":"ESP","LK":"LKA","SD":"SDN","SR":"SUR","SE":"SWE","CH":"CHE","SY":"SYR","TW":"TWN","TJ":"TJK","TZ":"TZA","TH":"THA","TL":"TLS","TG":"TGO","TT":"TTO","TN":"TUN","TR":"TUR","TM":"TKM","UG":"UGA","UA":"UKR","AE":"ARE","GB":"GBR","US":"USA","UY":"URY","UZ":"UZB","VU":"VUT","VE":"VEN","VN":"VNM","YE":"YEM","ZM":"ZMB","ZW":"ZWE"}
 
 export default function AtlasPage(): React.ReactElement {
   const { t, language } = useTranslation()
@@ -186,22 +190,24 @@ export default function AtlasPage(): React.ReactElement {
 
   const atlas_country_options = useMemo(() => {
     if (!geoData) return []
+    // Precompute A3 → A2 reverse lookup once per geoData change instead of
+    // scanning A2_TO_A3 for every feature that needs the fallback.
+    const a3ToA2 = new Map<string, string>()
+    for (const [a2Key, a3Val] of Object.entries(A2_TO_A3)) a3ToA2.set(a3Val, a2Key)
+
     const opts: { code: string; label: string }[] = []
     const seen = new Set<string>()
     for (const f of (geoData as any).features || []) {
-      let a2 = f?.properties?.ISO_A2
-      if (!a2 || a2 === '-99' || typeof a2 !== 'string' || a2.length !== 2) {
+      const rawA2 = f?.properties?.ISO_A2
+      let resolvedA2: string | null = (typeof rawA2 === 'string' && rawA2.length === 2 && rawA2 !== '-99') ? rawA2 : null
+      if (!resolvedA2) {
         const a3 = f?.properties?.ADM0_A3 || f?.properties?.ISO_A3 || f?.properties?.['ISO3166-1-Alpha-3'] || null
-        if (a3 && a3 !== '-99') {
-          const a3ToA2Entry = Object.entries(A2_TO_A3).find(([, v]) => v === a3)
-          a2 = a3ToA2Entry ? a3ToA2Entry[0] : null
-        }
+        if (a3 && a3 !== '-99') resolvedA2 = a3ToA2.get(a3) ?? null
       }
-      if (!a2 || typeof a2 !== 'string' || a2.length !== 2) continue
-      if (seen.has(a2)) continue
-      seen.add(a2)
-      const label = String(resolveName(a2) || f?.properties?.NAME || f?.properties?.ADMIN || a2)
-      opts.push({ code: a2, label })
+      if (!resolvedA2 || seen.has(resolvedA2)) continue
+      seen.add(resolvedA2)
+      const label = String(resolveName(resolvedA2) || f?.properties?.NAME || f?.properties?.ADMIN || resolvedA2)
+      opts.push({ code: resolvedA2, label })
     }
     opts.sort((a, b) => a.label.localeCompare(b.label))
     return opts


### PR DESCRIPTION
France, Norway and potentially other countries are missing from the Atlas country search because their Natural Earth GeoJSON records carry ISO_A2 = '-99'. This PR fixes the search option builder to fall back to ADM0_A3/ISO_A3 and reverse-map to A2 when the primary code is invalid.

## Changes:
- Fall back to A3→A2 reverse lookup in atlas_country_options when ISO_A2 === '-99'
- Precompute the reverse-lookup Map once per geoData change (replaces per-feature Object.entries().find())
- Collapse vestigial A2_TO_A3_BASE + clone into a single const A2_TO_A3; add a comment documenting the load-bearing invariant for -99 countries
- Extend FE-PAGE-ATLAS-041 to cover both France and Norway via it.each

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
