### PR TITLE
fix(immich): serve fullsize thumbnail for original to fix HEIC rendering

### DIFF
--- a/server/src/services/memories/immichService.ts
+++ b/server/src/services/memories/immichService.ts
@@ -241,9 +241,10 @@ export async function streamImmichAsset(
   const creds = getImmichCredentials(effectiveUserId);
   if (!creds) return { error: 'Not found', status: 404 };
 
-  const path = kind === 'thumbnail' ? 'thumbnail' : 'original';
   const timeout = kind === 'thumbnail' ? 10000 : 30000;
-  const url = `${creds.immich_url}/api/assets/${assetId}/${path}`;
+  const url = kind === 'thumbnail'
+    ? `${creds.immich_url}/api/assets/${assetId}/thumbnail?size=thumbnail`
+    : `${creds.immich_url}/api/assets/${assetId}/thumbnail?size=fullsize`;
 
   response.set('Cache-Control', 'public, max-age=86400');
   await pipeAsset(url, response, { 'x-api-key': creds.immich_api_key }, AbortSignal.timeout(timeout));

--- a/server/tests/integration/memories-immich.test.ts
+++ b/server/tests/integration/memories-immich.test.ts
@@ -407,7 +407,7 @@ describe('Immich asset proxy', () => {
       .set('Cookie', authCookie(member.id));
 
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toContain('image/jpeg');
+    expect(res.headers['content-type']).toContain('image/');
   });
 
   it('IMMICH-057 — GET /assets/info where trip does not exist returns 403', async () => {


### PR DESCRIPTION
Raw /assets/{id}/original returns HEIC bytes which only Safari can render natively. Switch to /assets/{id}/thumbnail?size=fullsize which Immich transcodes to a browser-compatible format.

Closes #668 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed
