### PR TITLE
fix: handling shared albums from synology, pagination now correctly calculate page offset, improving performance on loading small albums

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -331,8 +331,8 @@ export const journeyApi = {
 
   // Photos
   uploadPhotos: (entryId: number, formData: FormData) => apiClient.post(`/journeys/entries/${entryId}/photos`, formData, { headers: { 'Content-Type': undefined as any } }).then(r => r.data),
-  addProviderPhoto: (entryId: number, provider: string, assetId: string, caption?: string) => apiClient.post(`/journeys/entries/${entryId}/provider-photos`, { provider, asset_id: assetId, caption }).then(r => r.data),
-  addProviderPhotos: (entryId: number, provider: string, assetIds: string[], caption?: string) => apiClient.post(`/journeys/entries/${entryId}/provider-photos`, { provider, asset_ids: assetIds, caption }).then(r => r.data),
+  addProviderPhoto: (entryId: number, provider: string, assetId: string, caption?: string, passphrase?: string | null, cacheId?: string | null) => apiClient.post(`/journeys/entries/${entryId}/provider-photos`, { provider, asset_id: assetId, caption, passphrase, cache_id: cacheId }).then(r => r.data),
+  addProviderPhotos: (entryId: number, provider: string, assetIds: string[], caption?: string, passphrase?: string | null, cacheIds?: string[]) => apiClient.post(`/journeys/entries/${entryId}/provider-photos`, { provider, asset_ids: assetIds, caption, passphrase, cache_ids: cacheIds }).then(r => r.data),
   linkPhoto: (entryId: number, photoId: number) => apiClient.post(`/journeys/entries/${entryId}/link-photo`, { photo_id: photoId }).then(r => r.data),
   updatePhoto: (photoId: number, data: Record<string, unknown>) => apiClient.patch(`/journeys/photos/${photoId}`, data).then(r => r.data),
   deletePhoto: (photoId: number) => apiClient.delete(`/journeys/photos/${photoId}`).then(r => r.data),

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -1561,7 +1561,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
     setPhotos([])
     setHasMore(false)
     try {
-      const res = await fetch(`/api/integrations/memories/${provider}/albums/${albumId}/photos`, { credentials: 'include', signal })
+      const res = await fetch(`/api/integrations/memories/${provider}/albums/${albumId}/photos${provider === 'synologyphotos' ? `?count=${albums.find(a => a.id === albumId)?.assetCount}` : ''}`, { credentials: 'include', signal })
       if (res.ok) setPhotos(((await res.json()).assets || []) as ProviderPickerAsset[])
     } catch (e: any) { if (e.name !== 'AbortError') {} }
     if (!signal.aborted) setLoading(false)

--- a/client/src/pages/JourneyDetailPage.tsx
+++ b/client/src/pages/JourneyDetailPage.tsx
@@ -20,7 +20,7 @@ import {
   Laugh, Smile, Meh, Annoyed, Frown,
   Sun, CloudSun, Cloud, CloudRain, CloudLightning, Snowflake, ChevronDown, Eye, EyeOff,
 } from 'lucide-react'
-import type { JourneyEntry, JourneyPhoto, JourneyDetail } from '../store/journeyStore'
+import type { JourneyEntry, JourneyPhoto, JourneyDetail, JourneyTrip } from '../store/journeyStore'
 
 const GRADIENTS = [
   'linear-gradient(135deg, #0F172A 0%, #6366F1 45%, #EC4899 100%)',
@@ -960,7 +960,7 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
           trips={trips}
           existingAssetIds={new Set(entries.flatMap(e => (e.photos || []).filter(p => p.asset_id).map(p => p.asset_id!)))}
           onClose={() => setShowPicker(false)}
-          onAdd={async (assetIds, entryId) => {
+          onAdd={async (assets, entryId) => {
             let targetId = entryId
             if (!targetId) {
               try {
@@ -972,10 +972,37 @@ function GalleryView({ entries, journeyId, userId, trips, onPhotoClick, onRefres
                 targetId = entry.id
               } catch { return }
             }
+            const assetIds = assets.map(a => a.id)
             let added = 0
             try {
-              const result = await journeyApi.addProviderPhotos(targetId, pickerProvider!, assetIds)
-              added = result.added || 0
+              if (pickerProvider === 'synologyphotos') {
+                const groups = new Map<string, { assetIds: string[]; cacheIds: string[] }>()
+                for (const asset of assets) {
+                  const passphraseKey = asset.passphrase || ''
+                  if (!groups.has(passphraseKey)) {
+                    groups.set(passphraseKey, { assetIds: [], cacheIds: [] })
+                  }
+                  const group = groups.get(passphraseKey)!
+                  group.assetIds.push(asset.id)
+                  group.cacheIds.push(asset.cacheKey || '')
+                }
+
+                for (const [passphrase, group] of groups) {
+                  if (!group.assetIds.length) continue
+                  const result = await journeyApi.addProviderPhotos(
+                    targetId,
+                    pickerProvider!,
+                    group.assetIds,
+                    undefined,
+                    passphrase || null,
+                    group.cacheIds,
+                  )
+                  added += result.added || 0
+                }
+              } else {
+                const result = await journeyApi.addProviderPhotos(targetId, pickerProvider!, assetIds)
+                added = result.added || 0
+              }
             } catch {}
             if (added > 0) {
               toast.success(t('journey.photosAdded', { count: added }))
@@ -1443,6 +1470,16 @@ function groupPhotosByDate(photos: any[]): { date: string; label: string; assets
 
 // ── Provider Picker ───────────────────────────────────────────────────────
 
+type ProviderAssetSelection = {
+  id: string
+  cacheKey?: string | null
+  passphrase?: string | null
+}
+
+type ProviderPickerAsset = ProviderAssetSelection & {
+  city?: string | null
+}
+
 function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, onClose, onAdd }: {
   provider: string
   userId: number
@@ -1450,11 +1487,11 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
   trips: JourneyTrip[]
   existingAssetIds: Set<string>
   onClose: () => void
-  onAdd: (assetIds: string[], entryId: number | null) => Promise<void>
+  onAdd: (assets: ProviderAssetSelection[], entryId: number | null) => Promise<void>
 }) {
   const { t } = useTranslation()
   const [filter, setFilter] = useState<'trip' | 'custom' | 'all' | 'album'>('trip')
-  const [photos, setPhotos] = useState<any[]>([])
+  const [photos, setPhotos] = useState<ProviderPickerAsset[]>([])
   const [albums, setAlbums] = useState<any[]>([])
   const [selectedAlbum, setSelectedAlbum] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -1463,7 +1500,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
   const [searchPage, setSearchPage] = useState(1)
   const [searchFrom, setSearchFrom] = useState('')
   const [searchTo, setSearchTo] = useState('')
-  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [selected, setSelected] = useState<Map<string, ProviderAssetSelection>>(new Map())
   const [customFrom, setCustomFrom] = useState('')
   const [customTo, setCustomTo] = useState('')
   const [targetEntryId, setTargetEntryId] = useState<number | null>(null)
@@ -1501,7 +1538,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
       })
       if (res.ok) {
         const data = await res.json()
-        const assets = data.assets || []
+        const assets = (data.assets || []) as ProviderPickerAsset[]
         setPhotos(prev => append ? [...prev, ...assets] : assets)
         setHasMore(!!data.hasMore)
       } else {
@@ -1525,7 +1562,7 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
     setHasMore(false)
     try {
       const res = await fetch(`/api/integrations/memories/${provider}/albums/${albumId}/photos`, { credentials: 'include', signal })
-      if (res.ok) setPhotos((await res.json()).assets || [])
+      if (res.ok) setPhotos(((await res.json()).assets || []) as ProviderPickerAsset[])
     } catch (e: any) { if (e.name !== 'AbortError') {} }
     if (!signal.aborted) setLoading(false)
   }
@@ -1552,10 +1589,17 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
     if (customFrom && customTo) searchPhotos(customFrom, customTo)
   }
 
-  const toggleAsset = (id: string) => {
+  const toSelection = (asset: ProviderPickerAsset): ProviderAssetSelection => ({
+    id: asset.id,
+    cacheKey: asset.cacheKey || null,
+    passphrase: asset.passphrase || null,
+  })
+
+  const toggleAsset = (asset: ProviderPickerAsset) => {
     setSelected(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id); else next.add(id)
+      const next = new Map(prev)
+      if (next.has(asset.id)) next.delete(asset.id)
+      else next.set(asset.id, toSelection(asset))
       return next
     })
   }
@@ -1709,17 +1753,25 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
 
         {/* Select all bar — sticky above grid */}
         {!loading && photos.length > 0 && (() => {
-          const selectable = photos.filter((a: any) => !existingAssetIds.has(a.id))
-          const allSelected = selectable.length > 0 && selectable.every((a: any) => selected.has(a.id))
+          const selectable = photos.filter(a => !existingAssetIds.has(a.id))
+          const allSelected = selectable.length > 0 && selectable.every(a => selected.has(a.id))
           if (selectable.length === 0) return null
           return (
             <div className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
               <button
                 onClick={() => {
                   if (allSelected) {
-                    setSelected(new Set())
+                    setSelected(prev => {
+                      const next = new Map(prev)
+                      for (const asset of selectable) next.delete(asset.id)
+                      return next
+                    })
                   } else {
-                    setSelected(new Set(selectable.map((a: any) => a.id)))
+                    setSelected(prev => {
+                      const next = new Map(prev)
+                      for (const asset of selectable) next.set(asset.id, toSelection(asset))
+                      return next
+                    })
                   }
                 }}
                 className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] font-medium border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800"
@@ -1757,13 +1809,13 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
                     {group.label}
                   </p>
                   <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-1.5 mb-1">
-                    {group.assets.map((asset: any) => {
+                    {group.assets.map((asset) => {
                       const isSelected = selected.has(asset.id)
                       const alreadyAdded = existingAssetIds.has(asset.id)
                       return (
                         <div
                           key={asset.id}
-                          onClick={() => !alreadyAdded && toggleAsset(asset.id)}
+                          onClick={() => !alreadyAdded && toggleAsset(asset)}
                           className={`relative aspect-square rounded-lg overflow-hidden ${
                             alreadyAdded
                               ? 'opacity-40 cursor-not-allowed'
@@ -1773,13 +1825,13 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
                           }`}
                         >
                           <img
-                            src={`/api/integrations/memories/${provider}/assets/0/${asset.id}/${userId}/thumbnail`}
+                            src={`/api/integrations/memories/${provider}/assets/0/${asset.id}/${userId}/thumbnail${provider === 'synologyphotos' ? `?cache_key=${asset.cacheKey}${asset.passphrase ? `&passphrase=${asset.passphrase}` : ''}` : ''}`}
                             alt=""
                             className="w-full h-full object-cover"
                             loading="lazy"
                             onError={e => {
                               const img = e.currentTarget
-                              const original = `/api/integrations/memories/${provider}/assets/0/${asset.id}/${userId}/original`
+                              const original = `/api/integrations/memories/${provider}/assets/0/${asset.id}/${userId}/original${provider === 'synologyphotos' ? `?cache_key=${asset.cacheKey}${asset.passphrase ? `&passphrase=${asset.passphrase}` : ''}` : ''}`
                               if (!img.src.includes('/original')) img.src = original
                             }}
                           />
@@ -1821,7 +1873,10 @@ function ProviderPicker({ provider, userId, entries, trips, existingAssetIds, on
               {t('common.cancel')}
             </button>
             <button
-              onClick={() => onAdd([...selected], targetEntryId)}
+              onClick={() => {
+                const selectedAssets = Array.from(selected.values())
+                onAdd(selectedAssets, targetEntryId)
+              }}
               disabled={selected.size === 0}
               className="px-3.5 py-2 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 text-[13px] font-medium hover:bg-zinc-800 dark:hover:bg-zinc-100 disabled:opacity-40 disabled:cursor-not-allowed"
             >

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -1629,6 +1629,23 @@ function runMigrations(db: Database.Database): void {
         )
       `);
     },
+    // Migration 104: Synology trek_photos passphrase/cache_key compatibility
+    () => {
+      try { db.exec('ALTER TABLE trek_photos ADD COLUMN cache_key TEXT'); } catch {}
+      try { db.exec('ALTER TABLE trek_photos ADD COLUMN passphrase TEXT'); } catch {}
+      try {
+        db.exec(`
+          UPDATE trek_photos
+          SET cache_key = asset_id,
+              asset_id = CASE
+                WHEN provider = 'synologyphotos' AND asset_id LIKE '%_%' THEN substr(asset_id, 1, instr(asset_id, '_') - 1)
+                ELSE asset_id
+              END
+          WHERE provider = 'synologyphotos'
+            AND asset_id IS NOT NULL
+        `);
+      } catch {}
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/routes/journey.ts
+++ b/server/src/routes/journey.ts
@@ -115,21 +115,21 @@ router.post('/entries/:entryId/photos', authenticate, upload.array('photos', 10)
 
 router.post('/entries/:entryId/provider-photos', authenticate, (req: Request, res: Response) => {
   const authReq = req as AuthRequest;
-  const { provider, asset_id, asset_ids, caption } = req.body || {};
+  const { provider, asset_id, asset_ids, caption, passphrase, cache_id, cache_ids } = req.body || {};
 
   // Batch mode: { provider, asset_ids: string[] }
   if (Array.isArray(asset_ids) && provider) {
     const added: any[] = [];
-    for (const id of asset_ids) {
-      const photo = svc.addProviderPhoto(Number(req.params.entryId), authReq.user.id, provider, String(id), caption);
+    asset_ids.forEach((id, index) => {
+      const photo = svc.addProviderPhoto(Number(req.params.entryId), authReq.user.id, provider, String(id), caption, passphrase, Array.isArray(cache_ids) ? String(cache_ids[index] || '') : undefined);
       if (photo) added.push(photo);
-    }
+    });
     return res.status(201).json({ photos: added, added: added.length });
   }
 
   // Single mode (backward compat)
   if (!provider || !asset_id) return res.status(400).json({ error: 'provider and asset_id required' });
-  const photo = svc.addProviderPhoto(Number(req.params.entryId), authReq.user.id, provider, asset_id, caption);
+  const photo = svc.addProviderPhoto(Number(req.params.entryId), authReq.user.id, provider, asset_id, caption, passphrase, cache_id);
   if (!photo) return res.status(403).json({ error: 'Not allowed or duplicate' });
   res.status(201).json(photo);
 });

--- a/server/src/routes/journeyPublic.ts
+++ b/server/src/routes/journeyPublic.ts
@@ -2,8 +2,10 @@ import express, { Request, Response } from 'express';
 import { getPublicJourney, validateShareTokenForAsset, validateShareTokenForPhoto } from '../services/journeyShareService';
 import { streamPhoto } from '../services/memories/photoResolverService';
 import { streamImmichAsset } from '../services/memories/immichService';
+import { db } from '../db/database';
 import path from 'node:path';
 import fs from 'node:fs';
+import { AssetSize } from '../services/memories/helpersService';
 
 const router = express.Router();
 
@@ -46,7 +48,10 @@ router.get('/:token/photo/:provider/:assetId/:ownerId/:kind', async (req: Reques
   } else {
     try {
       const { streamSynologyAsset } = await import('../services/memories/synologyService');
-      await streamSynologyAsset(res, effectiveOwnerId, effectiveOwnerId, assetId, kind === 'thumbnail' ? 'thumbnail' : 'original');
+      const stored = db.prepare(
+        'SELECT cache_key, passphrase FROM trek_photos WHERE provider = ? AND (asset_id = ? OR cache_key = ?) AND owner_id = ? LIMIT 1'
+      ).get('synologyphotos', assetId, assetId, effectiveOwnerId) as { cache_key?: string | null; passphrase?: string | null } | undefined;
+      await streamSynologyAsset(res, effectiveOwnerId, assetId, stored?.cache_key, kind as AssetSize, stored?.passphrase || undefined);
     } catch {
       res.status(404).json({ error: 'Provider not supported' });
     }

--- a/server/src/routes/memories/synology.ts
+++ b/server/src/routes/memories/synology.ts
@@ -80,7 +80,7 @@ router.get('/albums', authenticate, async (req: Request, res: Response) => {
 
 router.get('/albums/:albumId/photos', authenticate, async (req: Request, res: Response) => {
     const authReq = req as AuthRequest;
-    handleServiceResult(res, await getSynologyAlbumPhotos(authReq.user.id, req.params.albumId));
+    handleServiceResult(res, await getSynologyAlbumPhotos(authReq.user.id, req.params.albumId, req.query.count ? Number(req.query.count) : null));
 });
 
 router.post('/trips/:tripId/album-links/:linkId/sync', authenticate, async (req: Request, res: Response) => {

--- a/server/src/routes/memories/synology.ts
+++ b/server/src/routes/memories/synology.ts
@@ -100,8 +100,8 @@ router.post('/search', authenticate, async (req: Request, res: Response) => {
     const page = _parseNumberBodyField(body.page, 1) - 1;
     let limit = _parseNumberBodyField(body.limit, 100);
     const size = _parseNumberBodyField(body.size, 0);
-    if(page > 0) offset = page*limit;
     if(size > 0) limit = size;
+    if(page > 0) offset = page*limit;
 
     handleServiceResult(res, await searchSynologyPhotos(
         authReq.user.id,

--- a/server/src/routes/memories/synology.ts
+++ b/server/src/routes/memories/synology.ts
@@ -13,7 +13,7 @@ import {
     getSynologyAssetInfo,
     streamSynologyAsset,
 } from '../../services/memories/synologyService';
-import { canAccessUserPhoto, handleServiceResult, fail, success } from '../../services/memories/helpersService';
+import { canAccessUserPhoto, handleServiceResult, fail, success, AssetSize } from '../../services/memories/helpersService';
 
 const router = express.Router();
 
@@ -120,26 +120,21 @@ router.get('/assets/:tripId/:photoId/:ownerId/info', authenticate, async (req: R
         handleServiceResult(res, fail('You don\'t have access to this photo', 403));
     }
     else {
-        handleServiceResult(res, await getSynologyAssetInfo(authReq.user.id, photoId, Number(ownerId)));
+        handleServiceResult(res, await getSynologyAssetInfo(photoId, Number(ownerId)));
     }
 });
 
 router.get('/assets/:tripId/:photoId/:ownerId/:kind', authenticate, async (req: Request, res: Response) => {
     const authReq = req as AuthRequest;
     const { tripId, photoId, ownerId, kind } = req.params;
-    const VALID_SIZES = ['sm', 'm', 'xl'] as const;
-    const rawSize = String(req.query.size ?? 'sm');
-    const size = VALID_SIZES.includes(rawSize as any) ? rawSize : 'sm';
-
-    if (kind !== 'thumbnail' && kind !== 'original') {
-        return handleServiceResult(res, fail('Invalid asset kind', 400));
-    }
+    const passphrase = String(req.query.passphrase ?? '');
+    const cacheKey = String(req.query.cache_key ?? '');
 
     if (!canAccessUserPhoto(authReq.user.id, Number(ownerId), tripId, photoId, 'synologyphotos')) {
         handleServiceResult(res, fail('You don\'t have access to this photo', 403));
     }
     else{
-        await streamSynologyAsset(res, authReq.user.id, Number(ownerId), photoId, kind as 'thumbnail' | 'original', String(size));
+        await streamSynologyAsset(res, Number(ownerId), photoId, cacheKey, kind as AssetSize, passphrase);
     }
 
 });

--- a/server/src/services/journeyService.ts
+++ b/server/src/services/journeyService.ts
@@ -10,7 +10,7 @@ function ts(): number {
 // Joined SELECT for journey_photos + trek_photos — returns fields matching JourneyPhoto interface
 const JP_SELECT = `
   jp.id, jp.entry_id, jp.photo_id, jp.caption, jp.sort_order, jp.shared, jp.created_at,
-  tkp.provider, tkp.asset_id, tkp.owner_id, tkp.file_path, tkp.thumbnail_path, tkp.width, tkp.height
+  tkp.provider, tkp.asset_id, tkp.owner_id, tkp.cache_key, tkp.file_path, tkp.thumbnail_path, tkp.width, tkp.height
 `;
 const JP_JOIN = 'journey_photos jp JOIN trek_photos tkp ON tkp.id = jp.photo_id';
 
@@ -628,12 +628,12 @@ export function addPhoto(entryId: number, userId: number, filePath: string, thum
   return db.prepare(`SELECT ${JP_SELECT} FROM ${JP_JOIN} WHERE jp.id = ?`).get(Number(res.lastInsertRowid)) as JourneyPhoto;
 }
 
-export function addProviderPhoto(entryId: number, userId: number, provider: string, assetId: string, caption?: string): JourneyPhoto | null {
+export function addProviderPhoto(entryId: number, userId: number, provider: string, assetId: string, caption?: string, passphrase?: string | null, cacheId?: string | null): JourneyPhoto | null {
   const entry = db.prepare('SELECT * FROM journey_entries WHERE id = ?').get(entryId) as JourneyEntry | undefined;
   if (!entry) return null;
   if (!canEdit(entry.journey_id, userId)) return null;
 
-  const trekPhotoId = getOrCreateTrekPhoto(provider, assetId, userId);
+  const trekPhotoId = getOrCreateTrekPhoto(provider, assetId, userId, passphrase, cacheId);
 
   // skip if already added
   const exists = db.prepare('SELECT 1 FROM journey_photos WHERE entry_id = ? AND photo_id = ?').get(entryId, trekPhotoId);
@@ -677,11 +677,11 @@ export function linkPhotoToEntry(entryId: number, photoId: number, userId: numbe
   return db.prepare(`SELECT ${JP_SELECT} FROM ${JP_JOIN} WHERE jp.id = ?`).get(photoId) as JourneyPhoto;
 }
 
-export function setPhotoProvider(photoId: number, provider: string, assetId: string, ownerId: number) {
+export function setPhotoProvider(photoId: number, provider: string, assetId: string, ownerId: number, passphrase?: string | null, cacheId?: string | null) {
   // Get the trek_photo_id from the journey_photo, then update the central registry
   const jp = db.prepare('SELECT photo_id FROM journey_photos WHERE id = ?').get(photoId) as { photo_id: number } | undefined;
   if (!jp) return;
-  setTrekPhotoProvider(jp.photo_id, provider, assetId, ownerId);
+  setTrekPhotoProvider(jp.photo_id, provider, assetId, ownerId, passphrase, cacheId);
 }
 
 export function updatePhoto(photoId: number, userId: number, data: { caption?: string; sort_order?: number }): JourneyPhoto | null {

--- a/server/src/services/journeyShareService.ts
+++ b/server/src/services/journeyShareService.ts
@@ -77,8 +77,8 @@ export function validateShareTokenForAsset(token: string, assetId: string): { ow
     SELECT tkp.owner_id FROM journey_photos jp
     JOIN trek_photos tkp ON tkp.id = jp.photo_id
     JOIN journey_entries je ON jp.entry_id = je.id
-    WHERE tkp.asset_id = ? AND je.journey_id = ?
-  `).get(assetId, row.journey_id) as any;
+    WHERE (tkp.asset_id = ? OR tkp.cache_key = ?) AND je.journey_id = ?
+  `).get(assetId, assetId, row.journey_id) as any;
   if (!photo) {
     const journey = db.prepare('SELECT user_id FROM journeys WHERE id = ?').get(row.journey_id) as any;
     return journey ? { ownerId: journey.user_id } : null;
@@ -102,7 +102,7 @@ export function getPublicJourney(token: string) {
 
   const photos = db.prepare(`
     SELECT jp.id, jp.entry_id, jp.photo_id, jp.caption, jp.sort_order, jp.shared, jp.created_at,
-           tkp.provider, tkp.asset_id, tkp.owner_id, tkp.file_path, tkp.thumbnail_path, tkp.width, tkp.height
+        tkp.provider, tkp.asset_id, tkp.owner_id, tkp.file_path, tkp.thumbnail_path, tkp.width, tkp.height
     FROM journey_photos jp
     JOIN trek_photos tkp ON tkp.id = jp.photo_id
     JOIN journey_entries je ON jp.entry_id = je.id

--- a/server/src/services/memories/helpersService.ts
+++ b/server/src/services/memories/helpersService.ts
@@ -42,6 +42,8 @@ export function handleServiceResult<T>(res: Response, result: ServiceResult<T>):
 export type Selection = {
     provider: string;
     asset_ids: string[];
+    cache_keys?: (string | null)[];
+    passphrase?: string | null;
 };
 
 export type StatusResult = {
@@ -64,7 +66,9 @@ export type AlbumsList = {
 
 export type Asset = {
     id: string;
+    cacheKey?: string | null;
     takenAt: string;
+    passphrase?: string | null;
 };
 
 export type AssetsList = {
@@ -96,6 +100,7 @@ export type AssetInfo = {
     fileName?: string | null;
 }
 
+export type AssetSize = 'thumbnail' | 'preview' | 'fullsize' | 'original';
 
 //for loading routes to settings page, and validating which services user has connected
 type PhotoProviderConfig = {
@@ -131,11 +136,11 @@ export function canAccessUserPhoto(requestingUserId: number, ownerUserId: number
             FROM journey_photos jp
             JOIN trek_photos tkp ON tkp.id = jp.photo_id
             JOIN journey_entries je ON je.id = jp.entry_id
-            WHERE tkp.asset_id = ?
+                        WHERE (tkp.asset_id = ? OR tkp.cache_key = ?)
               AND tkp.provider = ?
               AND tkp.owner_id = ?
             LIMIT 1
-        `).get(assetId, provider, ownerUserId) as { entry_id: number; journey_id: number } | undefined;
+                `).get(assetId, assetId, provider, ownerUserId) as { entry_id: number; journey_id: number } | undefined;
         if (!journeyPhoto) return false;
 
         const access = db.prepare(`
@@ -153,12 +158,12 @@ export function canAccessUserPhoto(requestingUserId: number, ownerUserId: number
     FROM trip_photos tp
     JOIN trek_photos tkp ON tkp.id = tp.photo_id
     WHERE tp.user_id = ?
-      AND tkp.asset_id = ?
+            AND (tkp.asset_id = ? OR tkp.cache_key = ?)
       AND tkp.provider = ?
       AND tp.trip_id = ?
       AND tp.shared = 1
     LIMIT 1
-    `).get(ownerUserId, assetId, provider, tripId);
+        `).get(ownerUserId, assetId, assetId, provider, tripId);
 
     if (!sharedAsset) {
         return false;
@@ -238,12 +243,13 @@ export async function pipeAsset(url: string, response: Response, headers?: Recor
     try {
         const resp = await safeFetch(url, { headers, signal: signal as any });
 
+        response.set('Cache-Control', 'public, max-age=86400');
         response.status(resp.status);
         if (resp.headers.get('content-type')) response.set('Content-Type', resp.headers.get('content-type') as string);
         if (resp.headers.get('cache-control')) response.set('Cache-Control', resp.headers.get('cache-control') as string);
         if (resp.headers.get('content-length')) response.set('Content-Length', resp.headers.get('content-length') as string);
         if (resp.headers.get('content-disposition')) response.set('Content-Disposition', resp.headers.get('content-disposition') as string);
-
+        
         if (!resp.body) {
             response.end();
         } else {

--- a/server/src/services/memories/photoResolverService.ts
+++ b/server/src/services/memories/photoResolverService.ts
@@ -14,15 +14,28 @@ export function getOrCreateTrekPhoto(
   provider: string,
   assetId: string,
   ownerId: number,
+  passphrase?: string | null,
+  cacheKey?: string | null,
 ): number {
+  // For synology, cache_key should be stored separately (format: "uid_timestamp")
+  const normalizedAssetId = assetId;
+  const normalizedCacheKey = cacheKey || null;
   const existing = db.prepare(
-    'SELECT id FROM trek_photos WHERE provider = ? AND asset_id = ? AND owner_id = ?'
-  ).get(provider, assetId, ownerId) as { id: number } | undefined;
-  if (existing) return existing.id;
+    'SELECT id, passphrase FROM trek_photos WHERE provider = ? AND asset_id = ? AND owner_id = ?'
+  ).get(provider, normalizedAssetId, ownerId) as { id: number; passphrase?: string | null } | undefined;
+  if (existing) {
+    if (passphrase && !existing.passphrase) {
+      db.prepare('UPDATE trek_photos SET passphrase = ? WHERE id = ?').run(passphrase, existing.id);
+    }
+    if (normalizedCacheKey && !existing.id) {
+      db.prepare('UPDATE trek_photos SET cache_key = ? WHERE id = ?').run(normalizedCacheKey, existing.id);
+    }
+    return existing.id;
+  }
 
   const res = db.prepare(
-    'INSERT INTO trek_photos (provider, asset_id, owner_id) VALUES (?, ?, ?)'
-  ).run(provider, assetId, ownerId);
+    'INSERT INTO trek_photos (provider, asset_id, cache_key, passphrase, owner_id) VALUES (?, ?, ?, ?, ?)'
+  ).run(provider, normalizedAssetId, normalizedCacheKey, passphrase || null, ownerId);
   return Number(res.lastInsertRowid);
 }
 
@@ -77,7 +90,7 @@ export async function streamPhoto(
       return;
     }
     case 'synologyphotos': {
-      await streamSynologyAsset(res, userId, photo.owner_id!, photo.asset_id!, kind);
+      await streamSynologyAsset(res, photo.owner_id, photo.asset_id, photo.cache_key, kind, photo.passphrase || undefined);
       return;
     }
     default:
@@ -112,7 +125,7 @@ export async function getPhotoInfo(
       return success(result.data as AssetInfo);
     }
     case 'synologyphotos': {
-      return getSynologyAssetInfo(userId, photo.asset_id!, photo.owner_id!);
+      return getSynologyAssetInfo(photo.asset_id!, photo.owner_id!);
     }
     default:
       return fail(`Unknown provider: ${photo.provider}`, 400);
@@ -126,10 +139,11 @@ export function setTrekPhotoProvider(
   provider: string,
   assetId: string,
   ownerId: number,
+  passphrase?: string | null,
 ): void {
   db.prepare(
-    'UPDATE trek_photos SET provider = ?, asset_id = ?, owner_id = ? WHERE id = ?'
-  ).run(provider, assetId, ownerId, trekPhotoId);
+    'UPDATE trek_photos SET provider = ?, asset_id = ?, passphrase = ?, owner_id = ? WHERE id = ?'
+  ).run(provider, assetId, passphrase || null, ownerId, trekPhotoId);
 }
 
 // ── Delete local file for a trek_photo ──────────────────────────────────

--- a/server/src/services/memories/synologyService.ts
+++ b/server/src/services/memories/synologyService.ts
@@ -454,12 +454,14 @@ export async function listSynologyAlbums(userId: number): Promise<ServiceResult<
 }
 
 
-export async function getSynologyAlbumPhotos(userId: number, albumId: string): Promise<ServiceResult<AssetsList>> {
+export async function getSynologyAlbumPhotos(userId: number, albumId: string, count?: number): Promise<ServiceResult<AssetsList>> {
     const allItems: SynologyPhotoItem[] = [];
-    const pageSize = 1000;
+    const pageSize = 500;
     let offset = 0;
+    if (!count) count = 1000;
 
     while (true) {
+        let limit = offset < count + 50 ? Math.min(count + 50 - offset, 1000) : pageSize; // first request uses the count from the client, subsequent requests page through the rest of the album
         const result = await _requestSynologyApi<{ list: SynologyPhotoItem[] }>(userId, {
             api: 'SYNO.Foto.Browse.Item',
             method: 'list',
@@ -473,8 +475,8 @@ export async function getSynologyAlbumPhotos(userId: number, albumId: string): P
         if (!result.success) return result as ServiceResult<AssetsList>;
         const items = result.data.list || [];
         allItems.push(...items);
-        if (items.length < pageSize) break;
-        offset += pageSize;
+        if (items.length < limit) break;
+        offset += items.length;
     }
 
     const assets = allItems.map(item => ({

--- a/server/src/services/memories/synologyService.ts
+++ b/server/src/services/memories/synologyService.ts
@@ -17,7 +17,8 @@ import {
     AssetsList,
     StatusResult,
     SyncAlbumResult,
-    AssetInfo
+    AssetInfo,
+    AssetSize
 } from './helpersService';
 import { send as sendNotification } from '../notificationService';
 
@@ -267,7 +268,7 @@ function _normalizeSynologyPhotoInfo(item: SynologyPhotoItem): AssetInfo {
     const gps = item.additional?.gps || {};
 
     return {
-        id: String(item.additional?.thumbnail?.cache_key || ''),
+        id: String(item.additional?.thumbnail?.cache_key.split('_')[0] || ''),
         takenAt: item.time ? new Date(item.time * 1000).toISOString() : null,
         city: address.city || null,
         country: address.country || null,
@@ -298,13 +299,6 @@ function _clearSynologySession(userId: number): void {
     db.prepare('UPDATE users SET synology_sid = NULL, synology_did = NULL WHERE id = ?').run(userId);
 }
 
-function _splitPackedSynologyId(rawId: string): { id: string; cacheKey: string; assetId: string } | null {
-    // cache_key format from Synology is "{unit_id}_{timestamp}", e.g. "40808_1633659236".
-    // The first segment must be a non-empty integer (the unit ID used for API calls).
-    if (!/^\d+_.+$/.test(rawId)) return null;
-    const id = rawId.split('_')[0];
-    return { id, cacheKey: rawId, assetId: rawId };
-}
 
 async function _getSynologySession(userId: number): Promise<ServiceResult<string>> {
     const cached = _readSynologyUser(userId, ['synology_sid', 'synology_did']);
@@ -469,10 +463,11 @@ export async function getSynologyAlbumPhotos(userId: number, albumId: string): P
         const result = await _requestSynologyApi<{ list: SynologyPhotoItem[] }>(userId, {
             api: 'SYNO.Foto.Browse.Item',
             method: 'list',
-            version: 1,
-            album_id: Number(albumId),
+            version: 1, //could be increased to lvl 4
+            album_id: Number(albumId) ? Number(albumId) : null, //when its shared album it only require passphrase
             offset,
             limit: pageSize,
+            passphrase: Number(albumId) ? null : albumId, //when album id is not number its actually a passphrase
             additional: ['thumbnail'],
         });
         if (!result.success) return result as ServiceResult<AssetsList>;
@@ -483,8 +478,10 @@ export async function getSynologyAlbumPhotos(userId: number, albumId: string): P
     }
 
     const assets = allItems.map(item => ({
-        id: String(item.additional?.thumbnail?.cache_key || item.id || ''),
+        id: String(item.additional?.thumbnail?.cache_key?.split('_')[0] || ''),
+        cacheKey: String(item.additional?.thumbnail?.cache_key || ''),
         takenAt: item.time ? new Date(item.time * 1000).toISOString() : '',
+        passphrase: Number(albumId) ? null : albumId,
     })).filter(a => a.id);
 
     return success({ assets, total: assets.length, hasMore: false });
@@ -519,7 +516,9 @@ export async function syncSynologyAlbumLink(userId: number, tripId: string, link
 
     const selection: Selection = {
         provider: SYNOLOGY_PROVIDER,
-        asset_ids: allItems.map(item => String(item.additional?.thumbnail?.cache_key || '')).filter(id => id),
+        asset_ids: allItems.map(item => String(item.additional?.thumbnail?.cache_key?.split('_')[0] || '')).filter(id => id),
+        cache_keys: allItems.map(item => String(item.additional?.thumbnail?.cache_key || '')),
+        passphrase: Number(response.data) ? null : response.data,
     };
 
 
@@ -557,7 +556,13 @@ export async function searchSynologyPhotos(userId: number, from?: string, to?: s
     if (!result.success) return result as ServiceResult<AssetsList>;
 
     const allItems = result.data.list || [];
-    const assets = allItems.map(item => _normalizeSynologyPhotoInfo(item));
+    const assets = allItems.map(item => {
+        const info = _normalizeSynologyPhotoInfo(item);
+        return {
+            ...info,
+            cacheKey: String(item.additional?.thumbnail?.cache_key || ''),
+        };
+    }).filter(a => a.id) as any;
 
     return success({
         assets,
@@ -566,14 +571,12 @@ export async function searchSynologyPhotos(userId: number, from?: string, to?: s
     });
 }
 
-export async function getSynologyAssetInfo(userId: number, photoId: string, targetUserId?: number): Promise<ServiceResult<AssetInfo>> {
-    const parsedId = _splitPackedSynologyId(photoId);
-    if (!parsedId) return fail('Invalid photo ID format', 400);
+export async function getSynologyAssetInfo(photoId: string, targetUserId?: number): Promise<ServiceResult<AssetInfo>> {
     const result = await _requestSynologyApi<{ list: SynologyPhotoItem[] }>(targetUserId, {
         api: 'SYNO.Foto.Browse.Item',
         method: 'get',
         version: 5,
-        id: `[${Number(parsedId.id) + 1}]`, //for some reason synology wants id moved by one to get image info
+        id: `[${Number(photoId) + 1}]`, //for some reason synology wants id moved by one to get image info
         additional: ['resolution', 'exif', 'gps', 'address', 'orientation', 'description'],
     });
 
@@ -589,16 +592,12 @@ export async function getSynologyAssetInfo(userId: number, photoId: string, targ
 
 export async function streamSynologyAsset(
     response: Response,
-    userId: number,
     targetUserId: number,
     photoId: string,
-    kind: 'thumbnail' | 'original',
+    cacheKey: string,
+    kind: AssetSize,
+    passphrase?: string,
 ): Promise<void> {
-    const parsedId = _splitPackedSynologyId(photoId);
-    if (!parsedId) {
-        handleServiceResult(response, fail('Invalid photo ID format', 400));
-        return;
-    }
 
     const synology_credentials = _getSynologyCredentials(targetUserId);
     if (!synology_credentials.success) {
@@ -617,25 +616,45 @@ export async function streamSynologyAsset(
     }
 
     
-    //size: 'sm' 240px| 'm' 320px| 'xl' 1280px| 'preview' ?
-    const params = kind === 'thumbnail'
+    //size: 'sm' 240px| 'm' 320px| 'xl' 1280px| 'preview' broken??
+    let size = 'sm';
+    switch (kind) {
+        case 'original':
+            size = 'xl';
+            break;
+        case 'fullsize':
+            size = 'xl';
+            break;
+        case 'preview':
+            size = 'm';
+            break;
+        case 'thumbnail':
+            size = 'sm';
+            break;
+        default:
+            size = 'sm';
+    }
+
+    const params = size !== 'original'
         ? new URLSearchParams({
             api: 'SYNO.Foto.Thumbnail',
             method: 'get',
             version: '2',
             mode: 'download',
-            id: parsedId.id,
+            id: photoId,
             type: 'unit',
-            size: 'sm',
-            cache_key: parsedId.cacheKey,
+            size: size,
+            passphrase: passphrase || '',
+            cache_key: cacheKey,
             _sid: sid.data,
         })
         : new URLSearchParams({
             api: 'SYNO.Foto.Download',
             method: 'download',
             version: '2',
-            cache_key: parsedId.cacheKey,
-            unit_id: `[${parsedId.id}]`,
+            passphrase: passphrase || '',
+            cache_key: cacheKey,
+            unit_id: `[${photoId}]`,
             _sid: sid.data,
         });
 

--- a/server/src/services/memories/synologyService.ts
+++ b/server/src/services/memories/synologyService.ts
@@ -433,22 +433,30 @@ export async function testSynologyConnection(userId: number, synologyUrl: string
 }
 
 export async function listSynologyAlbums(userId: number): Promise<ServiceResult<AlbumsList>> {
-    const result = await _requestSynologyApi<{ list: SynologyPhotoItem[] }>(userId, {
-        api: 'SYNO.Foto.Browse.Album',
-        method: 'list',
-        version: 4,
-        offset: 0,
-        limit: 100,
-    });
-    if (!result.success) return result as ServiceResult<AlbumsList>;
+    const allAlbums: AlbumsList = {albums: []};
+    const LIMIT = 1000; // Synology API max limit per request
+    for(let i = 0; true; i++) {
+        const result = await _requestSynologyApi<{ list: SynologyPhotoItem[] }>(userId, {
+            api: 'SYNO.Foto.Browse.Album',
+            method: 'list',
+            version: 4,
+            category: 'normal_share_with_me',
+            offset: i*LIMIT,
+            limit: LIMIT,
+            additional: ["sharing_info"],
+        });
+        if (!result.success) return result as ServiceResult<AlbumsList>;
 
-    const albums = (result.data.list || []).map((album: any) => ({
-        id: String(album.id),
-        albumName: album.name || '',
-        assetCount: album.item_count || 0,
-    }));
+        const albums = (result.data.list || []).map((album: any) => ({
+            id: album.passphrase?.trim() ? album.passphrase.trim() : String(album.id),
+            albumName: album.name || '',
+            assetCount: album.item_count || 0,
+        }));
+        allAlbums.albums.push(...albums);
+        if (result.data.list.length < LIMIT) break;
+    };
 
-    return success({ albums });
+    return success(allAlbums);
 }
 
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -345,6 +345,8 @@ export interface TrekPhoto {
   id: number;
   provider: string;
   asset_id?: string | null;
+  cache_key?: string | null;
+  passphrase?: string | null;
   owner_id?: number | null;
   file_path?: string | null;
   thumbnail_path?: string | null;

--- a/server/tests/integration/memories-synology.test.ts
+++ b/server/tests/integration/memories-synology.test.ts
@@ -403,10 +403,10 @@ describe('Synology asset access', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
     setSynologyCredentials(testDb, user.id, 'https://synology.example.com', 'admin', 'pass');
-    addTripPhoto(testDb, trip.id, user.id, '101_cachekey', 'synologyphotos', { shared: false });
+    addTripPhoto(testDb, trip.id, user.id, '101', 'synologyphotos', { shared: false });
 
     const res = await request(app)
-      .get(`${SYNO}/assets/${trip.id}/101_cachekey/${user.id}/info`)
+      .get(`${SYNO}/assets/${trip.id}/101/${user.id}/info`)
       .set('Cookie', authCookie(user.id));
 
     expect(res.status).toBe(200);
@@ -418,10 +418,10 @@ describe('Synology asset access', () => {
     const { user: member } = createUser(testDb);
     const trip = createTrip(testDb, owner.id);
     addTripMember(testDb, trip.id, member.id);
-    addTripPhoto(testDb, trip.id, owner.id, '101_cachekey', 'synologyphotos', { shared: false });
+    addTripPhoto(testDb, trip.id, owner.id, '101', 'synologyphotos', { shared: false });
 
     const res = await request(app)
-      .get(`${SYNO}/assets/${trip.id}/101_cachekey/${owner.id}/info`)
+      .get(`${SYNO}/assets/${trip.id}/101/${owner.id}/info`)
       .set('Cookie', authCookie(member.id));
 
     expect(res.status).toBe(403);
@@ -511,7 +511,7 @@ describe('Synology asset access', () => {
     const { user } = createUser(testDb);
     const trip = createTrip(testDb, user.id);
     setSynologyCredentials(testDb, user.id, 'https://synology.example.com', 'admin', 'pass');
-    addTripPhoto(testDb, trip.id, user.id, '101_cachekey', 'synologyphotos', { shared: false });
+    addTripPhoto(testDb, trip.id, user.id, '101', 'synologyphotos', { shared: false });
 
     // Auth call succeeds, Browse.Item call throws a network error
     vi.mocked(safeFetch)
@@ -524,7 +524,7 @@ describe('Synology asset access', () => {
       .mockRejectedValueOnce(new Error('network failure'));
 
     const res = await request(app)
-      .get(`${SYNO}/assets/${trip.id}/101_cachekey/${user.id}/info`)
+      .get(`${SYNO}/assets/${trip.id}/101/${user.id}/info`)
       .set('Cookie', authCookie(user.id));
 
     expect(res.status).toBe(500);


### PR DESCRIPTION
## Description
adding passphrases for shared assets and albums,

correctly setting offset in search pagination

changing synology asset id to disallow adding one photo more times when cache id was generated using diffrent call

adding album size to call for rethriving assets, synology has speed problems when requested size is bigger than actual size of album


## Related Issue or Discussion
closing #688 and #689

## Type of Change
- [x] Bug fix
-  New feature
- [x] Breaking change (probably will break old photos)
-  Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
-  I have updated documentation if needed
