### PR TITLE
Raise PWA precache limit to unblock mapbox-gl build

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       workbox: {
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,svg,png,woff,woff2,ttf}'],
         navigateFallback: 'index.html',
         navigateFallbackDenylist: [/^\/api/, /^\/uploads/, /^\/mcp/],


### PR DESCRIPTION
Client-Bundle wuchs durch `mapbox-gl` auf ~6.5 MB und überschreitet damit das bisherige Workbox-Precache-Limit von 5 MB. `vite-plugin-pwa` bricht den Build dadurch mit Exit 1 ab — Auto-Deploys auf dev schlagen seit Commit 25bdf56 still fehl (Container läuft weiter mit altem Image). Limit auf 10 MB angehoben.