### PR TITLE
Allow mapbox-gl in CSP

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -94,8 +94,11 @@ export function createApp(): express.Application {
           "https://unpkg.com", "https://open-meteo.com", "https://api.open-meteo.com",
           "https://geocoding-api.open-meteo.com", "https://api.exchangerate-api.com",
           "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_50m_admin_0_countries.geojson",
-          "https://router.project-osrm.org/route/v1/"
+          "https://router.project-osrm.org/route/v1/",
+          "https://api.mapbox.com", "https://*.tiles.mapbox.com", "https://events.mapbox.com"
         ],
+        workerSrc: ["'self'", "blob:"],
+        childSrc: ["'self'", "blob:"],
         fontSrc: ["'self'", "https://fonts.gstatic.com", "data:"],
         objectSrc: ["'none'"],
         frameSrc: ["'none'"],


### PR DESCRIPTION
`mapbox-gl` (eingeführt in #740) bricht zur Laufzeit an der serverseitigen Content-Security-Policy: Style-API auf `api.mapbox.com` wird in `connect-src` geblockt, und das Worker-Spawning aus Blob-URLs schlägt fehl, weil `worker-src` nicht gesetzt ist und auf `script-src 'self'` zurückfällt.

- `connect-src` ergänzt um `api.mapbox.com`, `*.tiles.mapbox.com`, `events.mapbox.com`
- `worker-src: 'self' blob:` hinzugefügt (Mapbox erzeugt Worker aus Blobs)
- `child-src: 'self' blob:` als Fallback für ältere Browser ohne worker-src-Support