### PR TITLE
docs(readme): move hero GIF to external release asset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,4 +25,3 @@
 *.eot  binary
 *.pdf  binary
 *.zip  binary
-.github/assets/TREK1.gif filter=lfs diff=lfs merge=lfs -text

--- a/.github/assets/TREK1.gif
+++ b/.github/assets/TREK1.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9153871a41ca2c53ab9188ea400eb45f4065680eae0ee0ebc3fbcf18373d99c
-size 95418702

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A self-hosted, real-time collaborative travel planner — with maps, budgets, pa
 
 <div align="center">
 
-<img src=".github/assets/TREK1.gif" alt="TREK — 60-second tour" width="100%" />
+<img src="https://github.com/mauriceboe/test/releases/download/readme-assets/TREK1.gif" alt="TREK — 60-second tour" width="100%" />
 
 </div>
 


### PR DESCRIPTION
## Summary

Removes the 91 MB product-tour GIF (`.github/assets/TREK1.gif`) from the repo entirely and references it from the README via an external GitHub Release asset URL.

## Why

The GIF was added in #752 via Git LFS to keep it out of the base git history. Unfortunately LFS-aware clients (the default for everyone who installed `git-lfs`) still download the blob on checkout — which made `git pull` noticeably slower for collaborators. There's no setting that makes this silently opt-in.

## Fix

- Deletes `.github/assets/TREK1.gif` and removes its LFS entry from `.gitattributes`
- README's hero `<img>` now points at `github.com/mauriceboe/test/releases/download/readme-assets/TREK1.gif` — a release asset on a dedicated media-hosting repo, served by GitHub's Fastly CDN
- Release assets are not part of git history, so clones and pulls don't touch the GIF
- Readers hitting the rendered README still see the inline animation (mobile GitHub app included)

Nothing else changes — same file, same render, just hosted externally.