### PR TITLE
fix: filter [Trip Photos] container from mobile public view (#764)

### DIFF
--- a/client/src/pages/JourneyPublicPage.tsx
+++ b/client/src/pages/JourneyPublicPage.tsx
@@ -219,7 +219,7 @@ export default function JourneyPublicPage() {
         {/* Mobile combined map+timeline (public, read-only) */}
         {isMobile && view === 'timeline' && perms.share_timeline && perms.share_map && (
           <MobileMapTimeline
-            entries={entries}
+            entries={timelineEntries}
             mapEntries={mapEntries.map(e => ({ id: String(e.id), lat: e.location_lat!, lng: e.location_lng!, title: e.title, mood: e.mood, entry_date: e.entry_date }))}
             dark={document.documentElement.classList.contains('dark')}
             readOnly


### PR DESCRIPTION
Follow-up to #768.

The filter for the synthetic `[Trip Photos]` / `Gallery` containers
was only applied to `timelineEntries`, but `MobileMapTimeline` (the
combined map+timeline view rendered on screens <1024px) was passed
the raw `entries` array. As a result the container still showed up
on mobile after #768.

Fix: pass `timelineEntries` to `MobileMapTimeline` so it shares the
same filter as the desktop timeline.

Reported by @solluh in #764.