### PR TITLE
fix: pass lat/lng/name to placePhoto in PDF thumbnail fetch

### DIFF
--- a/client/src/components/PDF/TripPDF.tsx
+++ b/client/src/components/PDF/TripPDF.tsx
@@ -101,7 +101,7 @@ async function fetchPlacePhotos(assignments) {
   await Promise.allSettled(
     toFetch.map(async (place) => {
       try {
-        const data = await mapsApi.placePhoto(place.google_place_id || place.osm_id)
+        const data = await mapsApi.placePhoto(place.google_place_id || place.osm_id, place.lat, place.lng, place.name)
         if (data.photoUrl) photoMap[place.id] = data.photoUrl
       } catch {}
     })


### PR DESCRIPTION
## Description
Follow-up to #781. The previous fix made the PDF fetch photos for `osm_id` places, but thumbnails were still missing because `mapsApi.placePhoto` was called without `lat`/`lng`/`name`.

Without those args, the Wikimedia fallback (used on instances with no Google Maps key) skips the photo entirely — `lat` parses as `NaN` on the server, the `!isNaN(lat)` guard rejects it, and the error gets cached for 5 minutes. The plan view (`PlaceAvatar` → `photoService`) already passes all three; this aligns the PDF path with the same behaviour.

## Related Issue or Discussion
Closes #781 (follow-up)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed