### PR TITLE
fix: bump synology cached thumbnail size sm->m (#782)

### DIFF
--- a/server/src/services/memories/synologyService.ts
+++ b/server/src/services/memories/synologyService.ts
@@ -627,7 +627,9 @@ export async function fetchSynologyThumbnailBytes(
         mode: 'download',
         id: parsedId.id,
         type: 'unit',
-        size: 'sm',
+        // Match the uncached streamSynologyAsset default — 'sm' (240px) looked
+        // pixelated on retina.
+        size: 'm',
         cache_key: parsedId.cacheKey,
         _sid: sid.data,
     });


### PR DESCRIPTION
Follow-up to #761. Reported by @tiquis0290 in #782.

`fetchSynologyThumbnailBytes` (the cached-to-disk thumbnail path
used by `streamCachedThumbnail`) was still hardcoded to size `sm`
(240px) while the uncached `streamSynologyAsset` default had been
bumped to `m` (320px) in #761. Result: newly added Synology assets
were still served at 240px on retina screens.

Fix: align the cached path with the streaming default.

The reporter also raises a broader concern about journey entry
cards needing even larger thumbnails (requesting size based on
render area + orientation). That's a rework, not a pre-release
fix, and is out of scope here.