### PR TITLE
fix(oidc,ui): restore Authentik login and fix mobile delete dialog

### DIFF
--- a/client/src/components/shared/ConfirmDialog.tsx
+++ b/client/src/components/shared/ConfirmDialog.tsx
@@ -41,7 +41,7 @@ export default function ConfirmDialog({
   return (
     <div
       className="fixed inset-0 z-[10000] flex items-center justify-center px-4 trek-backdrop-enter"
-      style={{ backgroundColor: 'rgba(15, 23, 42, 0.5)' }}
+      style={{ backgroundColor: 'rgba(15, 23, 42, 0.5)', paddingBottom: 'var(--bottom-nav-h)' }}
       onClick={onClose}
     >
       <div

--- a/client/src/components/shared/CopyTripDialog.tsx
+++ b/client/src/components/shared/CopyTripDialog.tsx
@@ -42,7 +42,7 @@ export default function CopyTripDialog({ isOpen, tripTitle, onClose, onConfirm }
   return (
     <div
       className="fixed inset-0 z-[10000] flex items-center justify-center px-4 trek-backdrop-enter"
-      style={{ backgroundColor: 'rgba(15, 23, 42, 0.5)' }}
+      style={{ backgroundColor: 'rgba(15, 23, 42, 0.5)', paddingBottom: 'var(--bottom-nav-h)' }}
       onClick={onClose}
     >
       <div

--- a/server/src/routes/oidc.ts
+++ b/server/src/routes/oidc.ts
@@ -112,7 +112,7 @@ router.get('/callback', async (req: Request, res: Response) => {
       tokenData.id_token,
       doc,
       config.clientId,
-      config.issuer,
+      (doc.issuer ?? '').replace(/\/+$/, '') || config.issuer,
     );
     if (idVerify.ok !== true) {
       const reason = 'error' in idVerify ? idVerify.error : 'unknown';

--- a/server/src/services/oidcService.ts
+++ b/server/src/services/oidcService.ts
@@ -140,11 +140,21 @@ export async function discover(issuer: string, discoveryUrl?: string | null): Pr
   const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch OIDC discovery document');
   const doc = (await res.json()) as OidcDiscoveryDoc;
-  // Validate that the discovery doc's issuer matches the operator-configured
-  // one. A MITM or compromised doc could otherwise supply a crafted issuer
-  // that passes jwt.verify() because we used doc.issuer as the expected value.
-  if (doc.issuer && doc.issuer.replace(/\/+$/, '') !== issuer) {
-    throw new Error(`OIDC discovery issuer mismatch: expected "${issuer}", got "${doc.issuer}"`);
+  // Validate that the discovery doc's issuer matches the operator-configured one.
+  // When no custom discoveryUrl is set, a mismatch signals a MITM or misconfiguration
+  // and we reject. When the operator explicitly overrides the discovery URL (e.g.
+  // Authentik realm paths), the discovery doc's issuer is the canonical value —
+  // trust it and warn rather than blocking login.
+  const docIssuer = doc.issuer?.replace(/\/+$/, '') ?? '';
+  if (docIssuer && docIssuer !== issuer) {
+    if (discoveryUrl) {
+      console.warn(
+        `[OIDC] Discovery doc issuer "${doc.issuer}" differs from configured OIDC_ISSUER "${issuer}". ` +
+        `Using discovery doc issuer for id_token verification (custom OIDC_DISCOVERY_URL is set).`,
+      );
+    } else {
+      throw new Error(`OIDC discovery issuer mismatch: expected "${issuer}", got "${doc.issuer}"`);
+    }
   }
   doc._issuer = url;
   discoveryCache = doc;

--- a/server/tests/unit/services/oidcService.test.ts
+++ b/server/tests/unit/services/oidcService.test.ts
@@ -219,6 +219,59 @@ describe('discover', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
     await expect(discover('https://bad-issuer.example.com')).rejects.toThrow();
   });
+
+  it('OIDC-SVC-037: accepts mismatched doc issuer when discoveryUrl is explicit', async () => {
+    const doc = {
+      issuer: 'https://auth.example.com/application/o/myapp/',
+      authorization_endpoint: 'https://auth.example.com/application/o/myapp/authorize/',
+      token_endpoint: 'https://auth.example.com/application/o/token/',
+      userinfo_endpoint: 'https://auth.example.com/application/o/userinfo/',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => doc }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await discover(
+      'https://auth.example.com',
+      'https://auth.example.com/application/o/myapp/.well-known/openid-configuration',
+    );
+
+    expect(result.issuer).toBe(doc.issuer);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('differs from configured OIDC_ISSUER'));
+    warnSpy.mockRestore();
+  });
+
+  it('OIDC-SVC-038: throws on mismatched doc issuer when discoveryUrl is omitted', async () => {
+    const doc = {
+      issuer: 'https://evil.example.com',
+      authorization_endpoint: 'https://unique-2.example.com/auth',
+      token_endpoint: 'https://unique-2.example.com/token',
+      userinfo_endpoint: 'https://unique-2.example.com/userinfo',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => doc }));
+
+    await expect(discover('https://unique-2.example.com')).rejects.toThrow(
+      'OIDC discovery issuer mismatch',
+    );
+  });
+
+  it('OIDC-SVC-039: trailing-slash-only mismatch with explicit discoveryUrl does not warn', async () => {
+    const doc = {
+      issuer: 'https://auth.example.com/',
+      authorization_endpoint: 'https://auth.example.com/auth',
+      token_endpoint: 'https://auth.example.com/token',
+      userinfo_endpoint: 'https://auth.example.com/userinfo',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => doc }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await discover(
+      'https://auth.example.com',
+      'https://auth.example.com/.well-known/openid-configuration',
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 // ── issuer trailing-slash regex (ReDoS guard) ─────────────────────────────────


### PR DESCRIPTION
## Description
Two bug fixes for TREK 3.0.3:

**#843 — Mobile portrait: delete/copy dialog buttons hidden behind bottom nav**
`ConfirmDialog` and `CopyTripDialog` use `fixed inset-0 flex items-center justify-center` without accounting for the sticky bottom nav height. Added `paddingBottom: 'var(--bottom-nav-h)'` to the overlay container — matching the pattern already used by `DashboardPage`, `DayDetailPanel`, and `JourneyDetailPage`. The CSS var is `0px` on desktop so there is no layout impact outside mobile.

**#844 — OIDC login broken for Authentik with custom `OIDC_DISCOVERY_URL`**
Authentik returns a canonical issuer with an application path (e.g. `https://auth.example.com/application/o/trips/`) in its discovery doc, which doesn't match the operator's `OIDC_ISSUER` base URL. The strict equality check at `discover()` (introduced after v2) rejects this as a mismatch and blocks login entirely. Fix: when `OIDC_DISCOVERY_URL` is explicitly set, trust the discovery doc's issuer and log a warning instead of throwing. Default discovery (no custom URL) keeps the strict rejection. The `verifyIdToken` call in the callback route now passes the discovery doc's issuer as `expectedIssuer`, which is what the OIDC spec requires the `iss` claim to match. Existing user records (`users.oidc_issuer`) are keyed on the operator-configured `OIDC_ISSUER` and are unaffected.

## Related Issue or Discussion
Closes #843
Closes #844

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [ ] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed