### PR TITLE
fix(packing): resolve avatar URL path for bag and category assignees

### DIFF
--- a/server/src/services/packingService.ts
+++ b/server/src/services/packingService.ts
@@ -1,4 +1,5 @@
 import { db, canAccessTrip } from '../db/database';
+import { avatarUrl } from './authService';
 
 const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b'];
 
@@ -131,7 +132,10 @@ export function listBags(tripId: string | number) {
     if (!membersByBag.has(m.bag_id)) membersByBag.set(m.bag_id, []);
     membersByBag.get(m.bag_id)!.push(m);
   }
-  return bags.map(b => ({ ...b, members: membersByBag.get(b.id) || [] }));
+  return bags.map(b => ({
+    ...b,
+    members: (membersByBag.get(b.id) || []).map(m => ({ ...m, avatar: avatarUrl(m) })),
+  }));
 }
 
 export function setBagMembers(tripId: string | number, bagId: string | number, userIds: number[]) {
@@ -140,11 +144,12 @@ export function setBagMembers(tripId: string | number, bagId: string | number, u
   db.prepare('DELETE FROM packing_bag_members WHERE bag_id = ?').run(bagId);
   const ins = db.prepare('INSERT OR IGNORE INTO packing_bag_members (bag_id, user_id) VALUES (?, ?)');
   for (const uid of userIds) ins.run(bagId, uid);
-  return db.prepare(`
+  const rows = db.prepare(`
     SELECT bm.user_id, u.username, u.avatar
     FROM packing_bag_members bm JOIN users u ON bm.user_id = u.id
     WHERE bm.bag_id = ?
-  `).all(bagId);
+  `).all(bagId) as { user_id: number; username: string; avatar: string | null }[];
+  return rows.map(m => ({ ...m, avatar: avatarUrl(m) }));
 }
 
 export function createBag(tripId: string | number, data: { name: string; color?: string }) {
@@ -260,7 +265,7 @@ export function getCategoryAssignees(tripId: string | number) {
   const assignees: Record<string, { user_id: number; username: string; avatar: string | null }[]> = {};
   for (const row of rows as any[]) {
     if (!assignees[row.category_name]) assignees[row.category_name] = [];
-    assignees[row.category_name].push({ user_id: row.user_id, username: row.username, avatar: row.avatar });
+    assignees[row.category_name].push({ user_id: row.user_id, username: row.username, avatar: avatarUrl(row) });
   }
 
   return assignees;
@@ -274,12 +279,13 @@ export function updateCategoryAssignees(tripId: string | number, categoryName: s
     for (const uid of userIds) insert.run(tripId, categoryName, uid);
   }
 
-  return db.prepare(`
+  const updated = db.prepare(`
     SELECT pca.user_id, u.username, u.avatar
     FROM packing_category_assignees pca
     JOIN users u ON pca.user_id = u.id
     WHERE pca.trip_id = ? AND pca.category_name = ?
-  `).all(tripId, categoryName);
+  `).all(tripId, categoryName) as { user_id: number; username: string; avatar: string | null }[];
+  return updated.map(m => ({ ...m, avatar: avatarUrl(m) }));
 }
 
 // ── Reorder ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description
`packingService` was returning raw avatar filenames from the DB (e.g. `abc123.jpg`) directly as the `avatar` field, instead of the resolved path `/uploads/avatars/abc123.jpg`. Every other service (`tripService`, `authService`) uses the `avatarUrl()` helper for this — packing was the exception. This caused broken profile images when a user with an uploaded avatar was assigned to a bag or packing category.

Fix: import `avatarUrl` from `authService` and apply it in all four avatar return points in `packingService`:
- `listBags` — bag member avatars
- `setBagMembers` — avatars returned after member assignment
- `getCategoryAssignees` — category assignee avatars
- `updateCategoryAssignees` — avatars returned after assignee update

## Related Issue or Discussion
<!-- For bug fixes: Closes #ISSUE_NUMBER -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [ ] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [ ] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed