### PR TITLE
fix(planner): prefetch budget items on trip page mount (#861)

### DIFF
--- a/client/src/pages/TripPlannerPage.tsx
+++ b/client/src/pages/TripPlannerPage.tsx
@@ -343,7 +343,10 @@ export default function TripPlannerPage(): React.ReactElement | null {
   }, [tripId])
 
   useEffect(() => {
-    if (tripId) tripActions.loadReservations(tripId)
+    if (tripId) {
+      tripActions.loadReservations(tripId)
+      tripActions.loadBudgetItems?.(tripId)
+    }
   }, [tripId])
 
   useTripWebSocket(tripId)


### PR DESCRIPTION
## Description

On a fresh session, the **Budget category** dropdown in the booking dialog (and transport dialog) only showed "Auto (from booking type)" — pre-existing categories were missing until the user visited the Budget tab.

`ReservationModal` and `TransportModal` derive `budgetCategories` from `useTripStore().budgetItems`, but `loadBudgetItems` was only triggered when the Budget tab was clicked or `BudgetPanel` mounted. `TripPlannerPage`'s mount effects loaded reservations, files, and accommodations — but never budget items.

Fix: call `tripActions.loadBudgetItems(tripId)` in the existing `tripId`-scoped mount effect alongside `loadReservations`, so categories are available from first render. The "Auto (from booking type)" option and its behaviour are fully preserved.

## Related Issue or Discussion

Closes #861

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is up to date with `dev`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed