### PR TITLE
(fix) multiply item weight_grams by quantity in bag total weight calc…

### DIFF
--- a/client/src/components/Packing/PackingListPanel.tsx
+++ b/client/src/components/Packing/PackingListPanel.tsx
@@ -1311,8 +1311,8 @@ export default function PackingListPanel({ tripId, items, openImportSignal = 0, 
 
           {bags.map(bag => {
             const bagItems = items.filter(i => i.bag_id === bag.id)
-            const totalWeight = bagItems.reduce((sum, i) => sum + (i.weight_grams || 0), 0)
-            const maxWeight = bag.weight_limit_grams || Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + (i.weight_grams || 0), 0)), 1)
+            const totalWeight = bagItems.reduce((sum, i) => sum + (i.weight_grams * i.quantity || 0), 0)
+            const maxWeight = bag.weight_limit_grams || Math.max(...bags.map(b => items.filter(i => i.bag_id === b.id).reduce((s, i) => s + (i.weight_grams * i.quantity || 0), 0)), 1)
             const pct = Math.min(100, Math.round((totalWeight / maxWeight) * 100))
             return (
               <BagCard key={bag.id} bag={bag} bagItems={bagItems} totalWeight={totalWeight} pct={pct} tripId={tripId} tripMembers={tripMembers} canEdit={canEdit} onDelete={() => handleDeleteBag(bag.id)} onUpdate={handleUpdateBag} onSetMembers={handleSetBagMembers} t={t} compact />


### PR DESCRIPTION
## Description
Currently the quantity does not effect the total bag weight.
The data is already there, I would just need to change the calculation of the weight of the bag in the frontend.

Use case: User Marco adds lunches with a weight estimation per lunch,  and can adjust the quantity for different trekking trips depending on how long the trek goes.

## Related Issue or Discussion
discord link:
https://discord.com/channels/1488298068427411591/1496176614801670244 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed

I tested it locally (manual).

I tried to run the test, but they are failing on my machine... i am not sure if i did something wrong or if the tests in general are not up to date. It did not give me the impressions, that the failing tests are associated with my very small change though, therfore i think this is a problem with my local dev env.
