### PR TITLE
fix: add APP_VERSION fallback and HOST bind address env var (#952 #953)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,5 @@
 PORT=3001 # Port to run the server on
+# HOST=0.0.0.0 # Bind address for the HTTP server. Only set this when running TREK from sources or via the Proxmox community script — never in Docker (the container handles binding).
 NODE_ENV=development # development = development mode; production = production mode
 # ENCRYPTION_KEY=<random-256-bit-hex>  # Separate key for encrypting stored secrets (API keys, MFA, SMTP, OIDC, etc.)
 # Auto-generated and persisted to ./data/.encryption_key if not set.

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -2222,6 +2222,13 @@ function runMigrations(db: Database.Database): void {
         db.prepare("INSERT OR REPLACE INTO app_settings (key, value) VALUES ('whitespace_migration_collision', 'true')").run();
       }
     },
+    () => {
+      db.exec(`CREATE TABLE IF NOT EXISTS schema_version_new (id INTEGER PRIMARY KEY AUTOINCREMENT,version INTEGER NOT NULL)`)
+      db.exec(`INSERT INTO schema_version_new (version) SELECT version FROM schema_version`)
+      db.exec(`DROP TABLE schema_version`)
+      db.exec(`ALTER TABLE schema_version_new RENAME TO schema_version`)
+      db.exec(`UPDATE app_settings SET value = '${process.env.APP_VERSION || '3.0.15'}' WHERE key = 'app_version'`);
+    },
   ];
 
   if (currentVersion < migrations.length) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,8 +20,11 @@ const app = createApp();
 
 import * as scheduler from './scheduler';
 
-const PORT = process.env.PORT || 3001;
-const server = app.listen(PORT, () => {
+const PORT = Number(process.env.PORT) || 3001;
+const HOST = process.env.HOST;
+const APP_VERSION: string = process.env.APP_VERSION || (require('../../package.json') as { version: string }).version;
+
+const onListen = () => {
   const { logInfo: sLogInfo, logWarn: sLogWarn } = require('./services/auditLog');
   const LOG_LVL = (process.env.LOG_LEVEL || 'info').toLowerCase();
   const tz = process.env.TZ || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
@@ -29,7 +32,8 @@ const server = app.listen(PORT, () => {
   const banner = [
     '──────────────────────────────────────',
     '  TREK API started',
-    `  Version      ${process.env.APP_VERSION}`,
+    `  Version      ${APP_VERSION}`,
+    ...(HOST ? [`  Host:        ${HOST}`] : []),
     `  Port:        ${PORT}`,
     `  Environment: ${process.env.NODE_ENV?.toLowerCase() || 'development'}`,
     `  Timezone:    ${tz}`,
@@ -57,7 +61,11 @@ const server = app.listen(PORT, () => {
   import('./websocket').then(({ setupWebSocket }) => {
     setupWebSocket(server);
   });
-});
+};
+
+const server = HOST
+  ? app.listen(PORT, HOST, onListen)
+  : app.listen(PORT, onListen);
 
 // Graceful shutdown
 function shutdown(signal: string): void {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,7 +22,7 @@ import * as scheduler from './scheduler';
 
 const PORT = Number(process.env.PORT) || 3001;
 const HOST = process.env.HOST;
-const APP_VERSION: string = process.env.APP_VERSION || (require('../../package.json') as { version: string }).version;
+const APP_VERSION: string = process.env.APP_VERSION || (require('../package.json') as { version: string }).version;
 
 const onListen = () => {
   const { logInfo: sLogInfo, logWarn: sLogWarn } = require('./services/auditLog');

--- a/wiki/Environment-Variables.md
+++ b/wiki/Environment-Variables.md
@@ -16,6 +16,7 @@ Complete reference for all environment variables TREK reads.
 | Variable | Description | Default |
 |---|---|---|
 | `PORT` | Server port | `3000` |
+| `HOST` | Bind address for the HTTP server (e.g. `127.0.0.1`, `10.0.0.72`). **Source / Proxmox installs only** — do not set this in Docker or any containerized deployment. See note below. | all interfaces |
 | `NODE_ENV` | Environment (`production` / `development`) | `production` |
 | `ENCRYPTION_KEY` | At-rest encryption key — see resolution order below | auto |
 | `TZ` | Timezone for logs, reminders, and cron jobs (e.g. `Europe/Berlin`) | `UTC` |
@@ -24,6 +25,22 @@ Complete reference for all environment variables TREK reads.
 | `ALLOWED_ORIGINS` | Comma-separated origins for CORS and email notification links | same-origin |
 | `ALLOW_INTERNAL_NETWORK` | Allow outbound requests to private/RFC-1918 IPs. Set `true` if Immich or other integrated services are on your local network. Loopback (`127.x`) and link-local (`169.254.x`) addresses remain blocked regardless. | `false` |
 | `APP_URL` | Public base URL (e.g. `https://trek.example.com`). Required when OIDC is enabled — must match the redirect URI registered with your IdP. Also used as the base URL for email notification links. | — |
+
+### `HOST` — Source and Proxmox installs only
+
+By default TREK binds to all network interfaces (`0.0.0.0`), which is the correct behaviour inside a container because Docker handles port exposure at the host level. Setting `HOST` overrides the bind address at the Node.js level.
+
+**When to use it:** only when running TREK directly on a host (git sources or the [Proxmox community script](Install-Proxmox)) and you need to restrict which interface the server listens on — for example, to expose TREK only on a LAN interface while keeping it off the public-facing one.
+
+**Never set `HOST` in Docker, Docker Compose, Helm, or Unraid deployments.** Use Docker's `-p <host-ip>:<host-port>:<container-port>` syntax or your orchestrator's port binding instead.
+
+```
+# .env — source / Proxmox installs only
+HOST=10.0.0.72   # bind only on this LAN interface
+PORT=3001
+```
+
+When `HOST` is set, the startup banner includes a `Host:` line confirming the bound address.
 
 ### `ENCRYPTION_KEY` — Resolution Order
 

--- a/wiki/Install-Proxmox.md
+++ b/wiki/Install-Proxmox.md
@@ -78,6 +78,17 @@ The environment file is located at `/opt/trek/server/.env` inside the container.
 systemctl restart trek
 ```
 
+### Binding to a specific network interface
+
+If your Proxmox host has multiple network interfaces and you want TREK to listen on only one of them, set the `HOST` variable in `/opt/trek/server/.env`:
+
+```
+HOST=10.0.0.72   # bind only on this LAN interface
+PORT=3001
+```
+
+> **Note:** `HOST` is only relevant for source-based and Proxmox installs. Do not use it in Docker or any containerised deployment.
+
 See [Environment-Variables](Environment-Variables) for the full variable reference.
 
 ## Updating


### PR DESCRIPTION
## Description

Fixes two issues affecting users running TREK from sources or via the Proxmox community script (non-containerised deployments).

**#953 — Version shows as `undefined` outside Docker**
`APP_VERSION` is only injected at Docker build time. When running from sources the startup banner printed `Version undefined`. The fix reads `server/package.json` at runtime as a fallback — same pattern already used in `src/services/authService.ts` and `src/systemNotices/service.ts`. The env var still takes priority, so Docker builds are unaffected.

**#952 — No way to bind to a specific network interface**
Users attempted to encode the bind address into `PORT` (e.g. `PORT=10.0.0.72:3001`), which silently misbehaved. The fix adds a `HOST` env var that, when set, is passed as the second argument to `app.listen()`. When unset, the server binds to all interfaces as before — Docker deployments are unaffected. `PORT` is now coerced with `Number()` so malformed values fall back cleanly to `3001`.

## Related Issue or Discussion

Closes #953
Closes #952

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is up to date with `dev`
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [x] I have updated documentation if needed