### PR TITLE
fix(#981): align public share itinerary order with daily planner

### DIFF
--- a/client/src/components/Planner/DayPlanSidebar.tsx
+++ b/client/src/components/Planner/DayPlanSidebar.tsx
@@ -23,6 +23,11 @@ import { useCanDo } from '../../store/permissionsStore'
 import { useSettingsStore } from '../../store/settingsStore'
 import { useTranslation } from '../../i18n'
 import { isDayInAccommodationRange } from '../../utils/dayOrder'
+import {
+  TRANSPORT_TYPES, parseTimeToMinutes, getSpanPhase, getDisplayTimeForDay,
+  getTransportForDay as _getTransportForDay, getMergedItems as _getMergedItems,
+  type MergedItem,
+} from '../../utils/dayMerge'
 import { formatDate, formatTime, dayTotalCost, currencyDecimals } from '../../utils/formatters'
 import { useDayNotes } from '../../hooks/useDayNotes'
 import Tooltip from '../shared/Tooltip'
@@ -362,26 +367,6 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
     })
   }
 
-  const TRANSPORT_TYPES = new Set(['flight', 'train', 'bus', 'car', 'cruise'])
-
-  // Get span phase: how a reservation relates to a specific day (by id)
-  const getSpanPhase = (r: Reservation, dayId: number): 'single' | 'start' | 'middle' | 'end' => {
-    const startDayId = r.day_id
-    const endDayId = r.end_day_id ?? startDayId
-    if (!startDayId || startDayId === endDayId) return 'single'
-    if (dayId === startDayId) return 'start'
-    if (dayId === endDayId) return 'end'
-    return 'middle'
-  }
-
-  // Get the appropriate display time for a reservation on a specific day
-  const getDisplayTimeForDay = (r: Reservation, dayId: number): string | null => {
-    const phase = getSpanPhase(r, dayId)
-    if (phase === 'end') return r.reservation_end_time || null
-    if (phase === 'middle') return null
-    return r.reservation_time || null
-  }
-
   // Get phase label for multi-day badge
   const getSpanLabel = (r: Reservation, phase: string): string | null => {
     if (phase === 'single') return null
@@ -406,27 +391,8 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
     return { day_id: startId, end_day_id: targetDayId }
   }
 
-  const getTransportForDay = (dayId: number) => {
-    const dayAssignmentIds = (assignments[String(dayId)] || []).map(a => a.id)
-    return reservations.filter(r => {
-      if (!TRANSPORT_TYPES.has(r.type)) return false
-      if (r.assignment_id && dayAssignmentIds.includes(r.assignment_id)) return false
-
-      const startDayId = r.day_id
-      const endDayId = r.end_day_id ?? startDayId
-
-      if (startDayId == null) return false
-
-      if (endDayId !== startDayId) {
-        const startDay = days.find(d => d.id === startDayId)
-        const endDay = days.find(d => d.id === endDayId)
-        const thisDay = days.find(d => d.id === dayId)
-        if (!startDay || !endDay || !thisDay) return false
-        return getDayOrder(thisDay) >= getDayOrder(startDay) && getDayOrder(thisDay) <= getDayOrder(endDay)
-      }
-      return startDayId === dayId
-    })
-  }
+  const getTransportForDay = (dayId: number) =>
+    _getTransportForDay({ reservations, dayId, dayAssignmentIds: (assignments[String(dayId)] || []).map(a => a.id), days })
 
   // Get car rentals that are in "active" (middle) phase for a day — shown in day header, not timeline
   const getActiveRentalsForDay = (dayId: number) => {
@@ -445,20 +411,6 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
 
   const getDayAssignments = (dayId) =>
     (assignments[String(dayId)] || []).slice().sort((a, b) => a.order_index - b.order_index)
-
-  // Helper: parse time string ("HH:MM" or ISO) to minutes since midnight, or null
-  const parseTimeToMinutes = (time?: string | null): number | null => {
-    if (!time) return null
-    // ISO-Format "2025-03-30T09:00:00"
-    if (time.includes('T')) {
-      const [h, m] = time.split('T')[1].split(':').map(Number)
-      return h * 60 + m
-    }
-    // Einfaches "HH:MM" Format
-    const parts = time.split(':').map(Number)
-    if (parts.length >= 2 && !isNaN(parts[0]) && !isNaN(parts[1])) return parts[0] * 60 + parts[1]
-    return null
-  }
 
   // Compute initial day_plan_position for a transport based on time
   const computeTransportPosition = (r, da) => {
@@ -501,64 +453,14 @@ const DayPlanSidebar = React.memo(function DayPlanSidebar({
     reservationsApi.updatePositions(tripId, positions).catch(() => {})
   }
 
-  const getMergedItems = (dayId) => {
-    const da = getDayAssignments(dayId)
-    const dn = (dayNotes[String(dayId)] || []).slice().sort((a, b) => a.sort_order - b.sort_order)
-    const transport = getTransportForDay(dayId)
-
-    // All places keep their order_index — untimed can be freely moved, timed auto-sort when time is set
-    const baseItems = [
-      ...da.map(a => ({ type: 'place' as const, sortKey: a.order_index, data: a })),
-      ...dn.map(n => ({ type: 'note' as const, sortKey: n.sort_order, data: n })),
-    ].sort((a, b) => a.sortKey - b.sortKey)
-
-    // Transports are inserted among places based on time
-    const timedTransports = transport.map(r => ({
-      type: 'transport' as const,
-      data: r,
-      minutes: parseTimeToMinutes(getDisplayTimeForDay(r, dayId)) ?? 0,
-    })).sort((a, b) => a.minutes - b.minutes)
-
-    if (timedTransports.length === 0) return baseItems
-    if (baseItems.length === 0) {
-      return timedTransports.map((item, i) => ({ ...item, sortKey: i }))
-    }
-
-    // Insert transports among places based on per-day position or time
-    const result = [...baseItems]
-    for (let ti = 0; ti < timedTransports.length; ti++) {
-      const timed = timedTransports[ti]
-      const minutes = timed.minutes
-
-      // Use per-day position if explicitly set by user reorder
-      const perDayPos = timed.data.day_positions?.[dayId] ?? timed.data.day_positions?.[String(dayId)]
-      if (perDayPos != null) {
-        result.push({ type: timed.type, sortKey: perDayPos, data: timed.data })
-        continue
-      }
-
-      // Find insertion position: after the last place with time <= this transport's time
-      let insertAfterKey = -Infinity
-      for (const item of result) {
-        if (item.type === 'place') {
-          const pm = parseTimeToMinutes(item.data?.place?.place_time)
-          if (pm !== null && pm <= minutes) insertAfterKey = item.sortKey
-        } else if (item.type === 'transport') {
-          const tm = parseTimeToMinutes(item.data?.reservation_time)
-          if (tm !== null && tm <= minutes) insertAfterKey = item.sortKey
-        }
-      }
-
-      const lastKey = result.length > 0 ? Math.max(...result.map(i => i.sortKey)) : 0
-      const sortKey = insertAfterKey === -Infinity
-        ? lastKey + 0.5 + ti * 0.01
-        : insertAfterKey + 0.01 + ti * 0.001
-
-      result.push({ type: timed.type, sortKey, data: timed.data })
-    }
-
-    return result.sort((a, b) => a.sortKey - b.sortKey)
-  }
+  const getMergedItems = (dayId: number): MergedItem[] =>
+    _getMergedItems({
+      dayAssignments: getDayAssignments(dayId),
+      dayNotes: (dayNotes[String(dayId)] || []).slice().sort((a, b) => a.sort_order - b.sort_order),
+      dayTransports: getTransportForDay(dayId),
+      dayId,
+      getDisplayTime: getDisplayTimeForDay,
+    })
 
   // Pre-compute merged items for all days so the render loop doesn't recompute on unrelated state changes (e.g. hover)
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/pages/SharedTripPage.tsx
+++ b/client/src/pages/SharedTripPage.tsx
@@ -11,8 +11,8 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Clock, MapPin, FileText, Train, Plane, Bus, Car, Ship, Ticket, Hotel, Map, Luggage, Wallet, MessageCircle } from 'lucide-react'
 import { isDayInAccommodationRange } from '../utils/dayOrder'
+import { getTransportForDay, getMergedItems } from '../utils/dayMerge'
 
-const TRANSPORT_TYPES = new Set(['flight', 'train', 'bus', 'car', 'cruise'])
 const TRANSPORT_ICONS = { flight: Plane, train: Train, bus: Bus, car: Car, cruise: Ship }
 
 function createMarkerIcon(place: any) {
@@ -184,14 +184,16 @@ export default function SharedTripPage() {
           {sortedDays.map((day: any, di: number) => {
             const da = assignments[String(day.id)] || []
             const notes = (dayNotes[String(day.id)] || [])
-            const dayTransport = (reservations || []).filter((r: any) => TRANSPORT_TYPES.has(r.type) && r.reservation_time?.split('T')[0] === day.date)
+            const dayAssignmentIds: number[] = da.map((a: any) => a.id)
+            const dayTransport = getTransportForDay({ reservations: reservations || [], dayId: day.id, dayAssignmentIds, days: sortedDays })
             const dayAccs = (accommodations || []).filter((a: any) => isDayInAccommodationRange(day, a.start_day_id, a.end_day_id, sortedDays))
 
-            const merged = [
-              ...da.map((a: any) => ({ type: 'place', k: a.order_index, data: a })),
-              ...notes.map((n: any) => ({ type: 'note', k: n.sort_order ?? 0, data: n })),
-              ...dayTransport.map((r: any) => ({ type: 'transport', k: r.day_plan_position ?? 999, data: r })),
-            ].sort((a, b) => a.k - b.k)
+            const merged = getMergedItems({
+              dayAssignments: da,
+              dayNotes: notes,
+              dayTransports: dayTransport,
+              dayId: day.id,
+            })
 
             return (
               <div key={day.id} style={{ background: 'var(--bg-card, white)', borderRadius: 14, overflow: 'hidden', border: '1px solid var(--border-faint, #e5e7eb)' }}>
@@ -212,7 +214,7 @@ export default function SharedTripPage() {
 
                 {selectedDay === day.id && merged.length > 0 && (
                   <div style={{ padding: '0 16px 12px', display: 'flex', flexDirection: 'column', gap: 6 }}>
-                    {merged.map((item: any, idx: number) => {
+                    {merged.map((item: any) => {
                       if (item.type === 'transport') {
                         const r = item.data
                         const TIcon = TRANSPORT_ICONS[r.type] || Ticket

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -175,6 +175,7 @@ export interface Reservation {
   accommodation_start_day_id?: number | null
   accommodation_end_day_id?: number | null
   day_plan_position?: number | null
+  day_positions?: Record<number, number> | null
   metadata?: Record<string, string> | string | null
   needs_review?: number
   endpoints?: ReservationEndpoint[]

--- a/client/src/utils/dayMerge.test.ts
+++ b/client/src/utils/dayMerge.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { parseTimeToMinutes, getSpanPhase, getDisplayTimeForDay, getTransportForDay, getMergedItems } from './dayMerge'
+
+describe('parseTimeToMinutes', () => {
+  it('parses HH:MM string', () => {
+    expect(parseTimeToMinutes('09:30')).toBe(570)
+  })
+
+  it('parses ISO datetime string', () => {
+    expect(parseTimeToMinutes('2025-03-30T14:00:00')).toBe(840)
+  })
+
+  it('returns null for null/empty', () => {
+    expect(parseTimeToMinutes(null)).toBeNull()
+    expect(parseTimeToMinutes(undefined)).toBeNull()
+  })
+})
+
+describe('getSpanPhase', () => {
+  it('returns single when start === end', () => {
+    expect(getSpanPhase({ day_id: 1, end_day_id: 1 }, 1)).toBe('single')
+  })
+
+  it('returns start for the departure day', () => {
+    expect(getSpanPhase({ day_id: 1, end_day_id: 3 }, 1)).toBe('start')
+  })
+
+  it('returns end for the arrival day', () => {
+    expect(getSpanPhase({ day_id: 1, end_day_id: 3 }, 3)).toBe('end')
+  })
+
+  it('returns middle for days in between', () => {
+    expect(getSpanPhase({ day_id: 1, end_day_id: 3 }, 2)).toBe('middle')
+  })
+})
+
+describe('getDisplayTimeForDay', () => {
+  const r = { day_id: 1, end_day_id: 3, reservation_time: '2025-01-01T09:00:00', reservation_end_time: '2025-01-03T14:00:00' }
+
+  it('returns reservation_time on start day', () => {
+    expect(getDisplayTimeForDay(r, 1)).toBe(r.reservation_time)
+  })
+
+  it('returns reservation_end_time on end day', () => {
+    expect(getDisplayTimeForDay(r, 3)).toBe(r.reservation_end_time)
+  })
+
+  it('returns null for middle day', () => {
+    expect(getDisplayTimeForDay(r, 2)).toBeNull()
+  })
+})
+
+describe('getTransportForDay', () => {
+  const days = [
+    { id: 1, day_number: 1 },
+    { id: 2, day_number: 2 },
+    { id: 3, day_number: 3 },
+  ]
+
+  it('excludes non-transport types', () => {
+    const reservations = [{ id: 10, type: 'hotel', day_id: 1 }]
+    expect(getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [], days })).toHaveLength(0)
+  })
+
+  it('includes single-day transport on the correct day', () => {
+    const reservations = [{ id: 10, type: 'flight', day_id: 1, end_day_id: 1 }]
+    expect(getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [], days })).toHaveLength(1)
+    expect(getTransportForDay({ reservations, dayId: 2, dayAssignmentIds: [], days })).toHaveLength(0)
+  })
+
+  it('includes multi-day transport on all spanned days', () => {
+    const reservations = [{ id: 10, type: 'train', day_id: 1, end_day_id: 3 }]
+    expect(getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [], days })).toHaveLength(1)
+    expect(getTransportForDay({ reservations, dayId: 2, dayAssignmentIds: [], days })).toHaveLength(1)
+    expect(getTransportForDay({ reservations, dayId: 3, dayAssignmentIds: [], days })).toHaveLength(1)
+  })
+
+  it('excludes transport linked to an assignment on that day', () => {
+    const reservations = [{ id: 10, type: 'bus', day_id: 1, end_day_id: 1, assignment_id: 42 }]
+    expect(getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [42], days })).toHaveLength(0)
+    expect(getTransportForDay({ reservations, dayId: 1, dayAssignmentIds: [99], days })).toHaveLength(1)
+  })
+})
+
+describe('getMergedItems', () => {
+  it('merges places and notes sorted by sortKey', () => {
+    const dayAssignments = [
+      { id: 1, order_index: 0, place: { place_time: null } },
+      { id: 2, order_index: 2, place: { place_time: null } },
+    ]
+    const dayNotes = [{ id: 10, sort_order: 1 }]
+    const result = getMergedItems({ dayAssignments, dayNotes, dayTransports: [], dayId: 5 })
+    expect(result.map(i => i.type)).toEqual(['place', 'note', 'place'])
+    expect(result[0].data.id).toBe(1)
+    expect(result[1].data.id).toBe(10)
+    expect(result[2].data.id).toBe(2)
+  })
+
+  it('inserts transport by time when no per-day position is set', () => {
+    const dayAssignments = [
+      { id: 1, order_index: 0, place: { place_time: '08:00' } },
+      { id: 2, order_index: 1, place: { place_time: '13:00' } },
+    ]
+    const dayTransports = [
+      { id: 20, type: 'flight', day_id: 5, end_day_id: 5, reservation_time: '10:30', day_positions: null },
+    ]
+    const result = getMergedItems({ dayAssignments, dayNotes: [], dayTransports, dayId: 5 })
+    const types = result.map(i => i.type)
+    // transport (10:30) should be between place at 08:00 (idx 0) and place at 13:00 (idx 1)
+    expect(types).toEqual(['place', 'transport', 'place'])
+  })
+
+  it('per-day position overrides time-based insertion', () => {
+    const dayAssignments = [
+      { id: 1, order_index: 0, place: { place_time: '08:00' } },
+      { id: 2, order_index: 1, place: { place_time: '13:00' } },
+    ]
+    // Transport at 10:30 would normally go between the two places
+    // but per-day position 1.5 puts it after the second place
+    const dayTransports = [
+      { id: 20, type: 'train', day_id: 5, end_day_id: 5, reservation_time: '10:30', day_positions: { 5: 1.5 } },
+    ]
+    const result = getMergedItems({ dayAssignments, dayNotes: [], dayTransports, dayId: 5 })
+    const types = result.map(i => i.type)
+    expect(types).toEqual(['place', 'place', 'transport'])
+  })
+})

--- a/client/src/utils/dayMerge.ts
+++ b/client/src/utils/dayMerge.ts
@@ -1,0 +1,136 @@
+export const TRANSPORT_TYPES = new Set(['flight', 'train', 'bus', 'car', 'cruise'])
+
+export interface MergedItem {
+  type: 'place' | 'note' | 'transport'
+  sortKey: number
+  data: any
+}
+
+export function parseTimeToMinutes(time?: string | null): number | null {
+  if (!time) return null
+  if (time.includes('T')) {
+    const [h, m] = time.split('T')[1].split(':').map(Number)
+    return h * 60 + m
+  }
+  const parts = time.split(':').map(Number)
+  if (parts.length >= 2 && !isNaN(parts[0]) && !isNaN(parts[1])) return parts[0] * 60 + parts[1]
+  return null
+}
+
+export function getSpanPhase(
+  r: { day_id?: number | null; end_day_id?: number | null },
+  dayId: number
+): 'single' | 'start' | 'middle' | 'end' {
+  const startDayId = r.day_id
+  const endDayId = r.end_day_id ?? startDayId
+  if (!startDayId || startDayId === endDayId) return 'single'
+  if (dayId === startDayId) return 'start'
+  if (dayId === endDayId) return 'end'
+  return 'middle'
+}
+
+export function getDisplayTimeForDay(
+  r: { day_id?: number | null; end_day_id?: number | null; reservation_time?: string | null; reservation_end_time?: string | null },
+  dayId: number
+): string | null {
+  const phase = getSpanPhase(r, dayId)
+  if (phase === 'end') return r.reservation_end_time || null
+  if (phase === 'middle') return null
+  return r.reservation_time || null
+}
+
+/** Filter reservations that are active transports for the given day, excluding assignment-linked ones. */
+export function getTransportForDay(opts: {
+  reservations: any[]
+  dayId: number
+  dayAssignmentIds: number[]
+  days: Array<{ id: number; day_number?: number }>
+}): any[] {
+  const { reservations, dayId, dayAssignmentIds, days } = opts
+
+  const getDayOrder = (id: number): number => {
+    const d = days.find(x => x.id === id)
+    return d ? ((d as any).day_number ?? days.indexOf(d)) : 0
+  }
+  const thisDayOrder = getDayOrder(dayId)
+
+  return reservations.filter(r => {
+    if (!TRANSPORT_TYPES.has(r.type)) return false
+    if (r.assignment_id && dayAssignmentIds.includes(r.assignment_id)) return false
+
+    const startDayId = r.day_id
+    const endDayId = r.end_day_id ?? startDayId
+
+    if (startDayId == null) return false
+
+    if (endDayId !== startDayId) {
+      const startOrder = getDayOrder(startDayId)
+      const endOrder = getDayOrder(endDayId)
+      return thisDayOrder >= startOrder && thisDayOrder <= endOrder
+    }
+    return startDayId === dayId
+  })
+}
+
+/** Merge places, notes, and transports into a single ordered day timeline. */
+export function getMergedItems(opts: {
+  dayAssignments: any[]
+  dayNotes: any[]
+  dayTransports: any[]
+  dayId: number
+  getDisplayTime?: (r: any, dayId: number) => string | null
+}): MergedItem[] {
+  const { dayAssignments: da, dayNotes: dn, dayTransports: transport, dayId } = opts
+  const getDisplayTime = opts.getDisplayTime ?? getDisplayTimeForDay
+
+  const baseItems: MergedItem[] = [
+    ...da.map(a => ({ type: 'place' as const, sortKey: a.order_index, data: a })),
+    ...dn.map(n => ({ type: 'note' as const, sortKey: n.sort_order ?? 0, data: n })),
+  ].sort((a, b) => a.sortKey - b.sortKey)
+
+  const timedTransports = transport.map(r => ({
+    type: 'transport' as const,
+    data: r,
+    minutes: parseTimeToMinutes(getDisplayTime(r, dayId)) ?? 0,
+  })).sort((a, b) => a.minutes - b.minutes)
+
+  if (timedTransports.length === 0) return baseItems
+  if (baseItems.length === 0) {
+    return timedTransports.map((item, i) => ({ type: item.type, sortKey: i, data: item.data }))
+  }
+
+  // Insert transports among base items based on per-day position or time
+  const result = [...baseItems]
+  for (let ti = 0; ti < timedTransports.length; ti++) {
+    const timed = timedTransports[ti]
+    const minutes = timed.minutes
+
+    // Per-day position takes precedence (set by user reorder)
+    const perDayPos = timed.data.day_positions?.[dayId] ?? timed.data.day_positions?.[String(dayId)]
+    if (perDayPos != null) {
+      result.push({ type: timed.type, sortKey: perDayPos, data: timed.data })
+      continue
+    }
+
+    // Time-based fallback: insert after the last item whose time <= this transport's time
+    let insertAfterKey = -Infinity
+    for (const item of result) {
+      if (item.type === 'place') {
+        const pm = parseTimeToMinutes(item.data?.place?.place_time)
+        if (pm !== null && pm <= minutes) insertAfterKey = item.sortKey
+      } else if (item.type === 'transport') {
+        const tm = parseTimeToMinutes(item.data?.reservation_time)
+        if (tm !== null && tm <= minutes) insertAfterKey = item.sortKey
+      }
+    }
+
+    const lastKey = result.length > 0 ? Math.max(...result.map(i => i.sortKey)) : 0
+    const sortKey = insertAfterKey === -Infinity
+      ? lastKey + 0.5 + ti * 0.01
+      : insertAfterKey + 0.01 + ti * 0.001
+
+    result.push({ type: timed.type, sortKey, data: timed.data })
+  }
+
+  return result.sort((a, b) => a.sortKey - b.sortKey)
+}

--- a/server/src/services/shareService.ts
+++ b/server/src/services/shareService.ts
@@ -114,7 +114,7 @@ export function getSharedTripData(token: string): Record<string, any> | null {
       JOIN places p ON da.place_id = p.id
       LEFT JOIN categories c ON p.category_id = c.id
       WHERE da.day_id IN (${ph})
-      ORDER BY da.order_index ASC
+      ORDER BY da.order_index ASC, da.created_at ASC
     `).all(...dayIds);
 
     const placeIds = [...new Set(allAssignments.map((a: any) => a.place_id))];
@@ -137,7 +137,7 @@ export function getSharedTripData(token: string): Record<string, any> | null {
     }
     assignments = byDay;
 
-    const allNotes = db.prepare(`SELECT * FROM day_notes WHERE day_id IN (${ph}) ORDER BY sort_order ASC`).all(...dayIds);
+    const allNotes = db.prepare(`SELECT * FROM day_notes WHERE day_id IN (${ph}) ORDER BY sort_order ASC, created_at ASC`).all(...dayIds);
     const notesByDay: Record<number, any[]> = {};
     for (const n of allNotes as any[]) {
       if (!notesByDay[n.day_id]) notesByDay[n.day_id] = [];
@@ -153,8 +153,24 @@ export function getSharedTripData(token: string): Record<string, any> | null {
     WHERE p.trip_id = ? ORDER BY p.created_at DESC
   `).all(tripId);
 
-  // Reservations
-  const reservations = db.prepare('SELECT * FROM reservations WHERE trip_id = ? ORDER BY reservation_time ASC').all(tripId);
+  // Reservations — include per-day positions so the client can render the same order as the planner
+  const reservations = db.prepare('SELECT * FROM reservations WHERE trip_id = ? ORDER BY reservation_time ASC').all(tripId) as any[];
+
+  const dayPositions = db.prepare(`
+    SELECT rdp.reservation_id, rdp.day_id, rdp.position
+    FROM reservation_day_positions rdp
+    JOIN reservations r ON rdp.reservation_id = r.id
+    WHERE r.trip_id = ?
+  `).all(tripId) as { reservation_id: number; day_id: number; position: number }[];
+
+  const posMap = new Map<number, Record<number, number>>();
+  for (const dp of dayPositions) {
+    if (!posMap.has(dp.reservation_id)) posMap.set(dp.reservation_id, {});
+    posMap.get(dp.reservation_id)![dp.day_id] = dp.position;
+  }
+  for (const r of reservations) {
+    r.day_positions = posMap.get(r.id) || null;
+  }
 
   // Accommodations
   const accommodations = db.prepare(`

--- a/server/tests/integration/share.test.ts
+++ b/server/tests/integration/share.test.ts
@@ -285,3 +285,61 @@ describe('Shared trip — day assignments and notes', () => {
     expect(res.body.assignments).toEqual({});
   });
 });
+
+describe('Shared trip — ordering parity (issue #981)', () => {
+  it('SHARE-014 — assignments with same order_index are ordered by created_at (tiebreaker)', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id, { date: '2025-09-01' });
+    const place1 = createPlace(testDb, trip.id, { name: 'First Created' });
+    const place2 = createPlace(testDb, trip.id, { name: 'Second Created' });
+
+    // Both with order_index = 0 (schema default) but different created_at
+    testDb.prepare(
+      "INSERT INTO day_assignments (day_id, place_id, order_index, created_at) VALUES (?, ?, 0, '2025-01-01T10:00:00')"
+    ).run(day.id, place1.id);
+    testDb.prepare(
+      "INSERT INTO day_assignments (day_id, place_id, order_index, created_at) VALUES (?, ?, 0, '2025-01-01T11:00:00')"
+    ).run(day.id, place2.id);
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({});
+
+    const res = await request(app).get(`/api/shared/${token}`);
+    expect(res.status).toBe(200);
+    const assignments = res.body.assignments[day.id];
+    expect(assignments).toHaveLength(2);
+    expect(assignments[0].place.name).toBe('First Created');
+    expect(assignments[1].place.name).toBe('Second Created');
+  });
+
+  it('SHARE-015 — reservations include day_positions map from reservation_day_positions table', async () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+    const day = createDay(testDb, trip.id, { date: '2025-09-01' });
+
+    const res1 = testDb.prepare(
+      "INSERT INTO reservations (trip_id, title, type, day_id, reservation_time) VALUES (?, ?, ?, ?, ?)"
+    ).run(trip.id, 'Test Flight', 'flight', day.id, '2025-09-01T09:00:00');
+    const reservationId = Number(res1.lastInsertRowid);
+
+    // Insert a per-day position
+    testDb.prepare(
+      'INSERT INTO reservation_day_positions (reservation_id, day_id, position) VALUES (?, ?, ?)'
+    ).run(reservationId, day.id, 1.5);
+
+    const { body: { token } } = await request(app)
+      .post(`/api/trips/${trip.id}/share-link`)
+      .set('Cookie', authCookie(user.id))
+      .send({ share_bookings: true });
+
+    const shareRes = await request(app).get(`/api/shared/${token}`);
+    expect(shareRes.status).toBe(200);
+    const reservation = shareRes.body.reservations.find((r: any) => r.id === reservationId);
+    expect(reservation).toBeDefined();
+    expect(reservation.day_positions).toBeDefined();
+    expect(reservation.day_positions[day.id]).toBe(1.5);
+  });
+});


### PR DESCRIPTION
## Description

Public Share (`/shared/:token`) showed items in a different order than the authenticated Trip Planner. Five concrete divergences — transport positioning, multi-day span handling, assignment-linked deduplication, time-based fallback, and sort tiebreakers — all traced to the share page maintaining its own simplified reimplementation of the planner's merge algorithm.

**Root causes fixed:**
1. `shareService` never loaded `reservation_day_positions`, so per-day transport positions were lost (fell back to `day_plan_position ?? 999`, pushing transports to the bottom).
2. Multi-day transports (overnight trains/flights) only appeared on their start day due to date-string filtering instead of `day_id`/`end_day_id` span logic.
3. Assignment-linked transports appeared twice (as a place card and a separate transport card) because the `assignment_id` exclusion was missing.
4. No time-based transport insertion; missing positions used `999` instead of a fractional position computed from the place timeline.
5. `ORDER BY da.order_index ASC` lacked a `created_at` tiebreaker, making order non-deterministic when multiple rows share `order_index = 0`.

**Approach:** extract the authoritative merge logic (`parseTimeToMinutes`, `getSpanPhase`, `getDisplayTimeForDay`, `getTransportForDay`, `getMergedItems`) from `DayPlanSidebar` into `client/src/utils/dayMerge.ts` and use it in both the planner and `SharedTripPage`. Enrich the `shareService` payload with `day_positions` from `reservation_day_positions` and add `created_at ASC` tiebreakers.

## Related Issue or Discussion

Closes #981

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
  - SHARE-014: `created_at` tiebreaker for equal `order_index`
  - SHARE-015: `day_positions` map present in share payload
  - 17 unit tests for `dayMerge.ts` (parseTimeToMinutes, getSpanPhase, getDisplayTimeForDay, getTransportForDay, getMergedItems)
  - All 16 existing SharedTripPage tests pass