### PR TITLE
fix: add 5 more bag colors to avoid duplicating colors

### DIFF
--- a/server/src/services/packingService.ts
+++ b/server/src/services/packingService.ts
@@ -1,7 +1,7 @@
 import { db, canAccessTrip } from '../db/database';
 import { avatarUrl } from './authService';
 
-const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b'];
+const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#32049e', '#ef4444', '#f59e0b', '#1106aa', '#99f70e', '#04463e', '#7f0e91', '#64748b' ];
 
 export function verifyTripAccess(tripId: string | number, userId: number) {
   return canAccessTrip(tripId, userId);


### PR DESCRIPTION
## Description
Added five more colors to avoid duplicating colors for subbags.

## Related Issue or Discussion
Discord: https://discord.com/channels/1488298068427411591/1496177702456131634

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed
