### PR TITLE
fix(pwa): removed orientation from the manifest

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -77,7 +77,6 @@ export default defineConfig({
         display: 'standalone',
         scope: '/',
         start_url: '/',
-        orientation: 'any',
         categories: ['travel', 'navigation'],
         icons: [
           { src: 'icons/apple-touch-icon-180x180.png', sizes: '180x180', type: 'image/png' },


### PR DESCRIPTION
## Description
When I installed PWA, it appeared that the application ignores the screen lock on Android. It means that when my screen is locked in portrait mode, the app still rotates itself when I rotate my phone.

This fix removes the orientation option as per the suggestion from the Stack - https://stackoverflow.com/questions/73956593/pwa-ignores-os-orientation-lock-on-android

## Related Issue or Discussion
<!-- This project requires an issue or an approved feature request before submitting a PR. -->
<!-- For bug fixes: Closes #ISSUE_NUMBER -->
<!-- For features: Addresses discussion #DISCUSSION_NUMBER -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [ ] I have added/updated tests that prove my fix is effective or that my feature works - not applicable
- [x] I have updated documentation if needed
