### PR TITLE
Fix inflated trip day_count after dateless → shorter dated updates

### DIFF
--- a/server/src/services/tripService.ts
+++ b/server/src/services/tripService.ts
@@ -125,13 +125,42 @@ export function generateDays(tripId: number | bigint | string, startDate: string
     del.run(dated[i].id);
   }
 
-  // Any remaining unused dateless days: keep as dateless, just renumber.
-  // Base must be max(targetDates.length, dated.length) to avoid colliding with
-  // positives already assigned by the main loop or the overflow loop above.
-  const maxAssigned = Math.max(targetDates.length, dated.length);
-  for (let i = datelessIdx; i < dateless.length; i++) {
-    setDayNumber.run(maxAssigned + (i - datelessIdx) + 1, dateless[i].id);
+  // Any remaining unused dateless days are stale once explicit dates are set.
+  // To avoid destroying user-entered data, only delete unused dateless days that
+  // are empty (no assignments, notes, or accommodations). Keep non-empty ones.
+  const unusedDatelessIds = dateless.slice(datelessIdx).map(d => d.id);
+  const idsPlaceholders = unusedDatelessIds.map(() => '?').join(', ');
+
+  const datelessWithContent = new Set<number>();
+  if (unusedDatelessIds.length > 0) {
+    const contentRows = db.prepare(
+      `SELECT DISTINCT day_id as id FROM day_assignments WHERE day_id IN (${idsPlaceholders})
+       UNION
+       SELECT DISTINCT day_id as id FROM day_notes WHERE day_id IN (${idsPlaceholders})
+       UNION
+       SELECT DISTINCT start_day_id as id FROM day_accommodations WHERE start_day_id IN (${idsPlaceholders})
+       UNION
+       SELECT DISTINCT end_day_id as id FROM day_accommodations WHERE end_day_id IN (${idsPlaceholders})`
+    ).all(...unusedDatelessIds, ...unusedDatelessIds, ...unusedDatelessIds, ...unusedDatelessIds) as { id: number }[];
+
+    contentRows.forEach(r => datelessWithContent.add(r.id));
   }
+
+  const keptDateless: { id: number }[] = [];
+  for (let i = datelessIdx; i < dateless.length; i++) {
+    const dayId = dateless[i].id;
+    const hasContent = datelessWithContent.has(dayId);
+    if (hasContent) {
+      keptDateless.push({ id: dayId });
+    } else {
+      del.run(dayId);
+    }
+  }
+
+  // Renumber retained dateless days after dated range, if any remain.
+  // Base must be max(targetDates.length, dated.length) to avoid collisions.
+  const maxAssigned = Math.max(targetDates.length, dated.length);
+  keptDateless.forEach((d, i) => setDayNumber.run(maxAssigned + i + 1, d.id));
 
   // Final renumber to compact and eliminate any gaps/negatives
   const remaining = db.prepare('SELECT id FROM days WHERE trip_id = ? ORDER BY day_number').all(tripId) as { id: number }[];

--- a/server/tests/integration/trips.test.ts
+++ b/server/tests/integration/trips.test.ts
@@ -488,6 +488,32 @@ describe('Update trip', () => {
     const all = testDb.prepare('SELECT * FROM day_assignments WHERE id IN (?, ?)').all(a4.id, a5.id) as { id: number }[];
     expect(all).toHaveLength(0);
   });
+
+  it('TRIP-028 — dateless(7) updated to dated(2) reports day_count=2 and removes stale placeholders', async () => {
+    const { user } = createUser(testDb);
+
+    const createRes = await request(app)
+      .post('/api/trips')
+      .set('Cookie', authCookie(user.id))
+      .send({ title: 'Open-ended', day_count: 7 });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.trip.day_count).toBe(7);
+
+    const tripId = createRes.body.trip.id;
+
+    const updateRes = await request(app)
+      .put(`/api/trips/${tripId}`)
+      .set('Cookie', authCookie(user.id))
+      .send({ start_date: '2026-10-01', end_date: '2026-10-02' });
+
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.trip.day_count).toBe(2);
+
+    const daysAfter = testDb.prepare('SELECT * FROM days WHERE trip_id = ? ORDER BY day_number').all(tripId) as { date: string | null }[];
+    expect(daysAfter).toHaveLength(2);
+    expect(daysAfter.map(d => d.date)).toEqual(['2026-10-01', '2026-10-02']);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/server/tests/unit/services/tripService.test.ts
+++ b/server/tests/unit/services/tripService.test.ts
@@ -208,7 +208,7 @@ describe('generateDays', () => {
     // Main loop: dated[0..2] → positions 1-3, dateless[0] → position 4 (consumed).
     // Unused dateless: dateless[1] should land at position 5, NOT 4 (collision bug).
     const { user } = createUser(testDb);
-    const trip = createTrip(testDb, user.id, { start_date: '2025-11-01', end_date: '2025-11-03' });
+    const trip = createTrip(testDb, user.id, { start_date: '2025-01-01', end_date: '2025-01-03' });
 
     // Insert 2 dateless days directly
     const daysBefore = getDays(trip.id);
@@ -224,7 +224,7 @@ describe('generateDays', () => {
 
     // Grow from 3 to 4 dated days — consumes dateless[0], leaves dateless[1] unused
     // This is the scenario that triggered the UNIQUE collision bug
-    generateDays(trip.id, '2025-11-01', '2025-11-04');
+    generateDays(trip.id, '2025-01-01', '2025-01-04');
 
     const daysAfter = getDays(trip.id);
     expect(daysAfter).toHaveLength(5);
@@ -241,6 +241,66 @@ describe('generateDays', () => {
     // All day_numbers are unique 1..5
     const nums = daysAfter.map(d => d.day_number).sort((a, b) => a - b);
     expect(nums).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('TRIP-SVC-017: dateless(7) -> dated(2) removes stale empty dateless placeholders', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { title: 'Open-ended' });
+    const insert = testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, NULL)');
+    for (let i = 1; i <= 7; i++) insert.run(trip.id, i);
+    expect(getDays(trip.id)).toHaveLength(7);
+
+    generateDays(trip.id, '2025-12-01', '2025-12-02');
+
+    const daysAfter = getDays(trip.id);
+    expect(daysAfter).toHaveLength(2);
+    expect(daysAfter.map(d => d.date)).toEqual(['2025-12-01', '2025-12-02']);
+  });
+
+  it('TRIP-SVC-018: dated -> dateless(day_count=X) trims trailing empty days to requested count', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2025-12-01', end_date: '2025-12-05' });
+    expect(getDays(trip.id)).toHaveLength(5);
+
+    // Clear dates and explicitly reduce to 3 dateless days.
+    generateDays(trip.id, null, null, undefined, 3);
+
+    const daysAfter = getDays(trip.id);
+    expect(daysAfter).toHaveLength(3);
+    expect(daysAfter.every(d => d.date === null)).toBe(true);
+  });
+
+  it('TRIP-SVC-019: unused non-empty dateless day is retained and renumbered for dated trips', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id, { start_date: '2026-01-01', end_date: '2026-01-03' });
+
+    // Add two dateless days after the dated range.
+    testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, NULL)').run(trip.id, 4);
+    testDb.prepare('INSERT INTO days (trip_id, day_number, date) VALUES (?, ?, NULL)').run(trip.id, 5);
+
+    const allDays = getDays(trip.id);
+    const datelessDay4 = allDays.find(d => d.day_number === 4)!;
+    const datelessDay5 = allDays.find(d => d.day_number === 5)!;
+
+    // Make day 5 non-empty so it must be kept if unused.
+    createDayNote(testDb, datelessDay5.id, trip.id, { text: 'keep me' });
+
+    // Grow to 4 dated days: day 4 gets consumed and dated, day 5 remains unused dateless.
+    generateDays(trip.id, '2026-01-01', '2026-01-04');
+
+    const daysAfter = getDays(trip.id);
+    expect(daysAfter).toHaveLength(5);
+
+    const remainingDay4 = daysAfter.find(d => d.id === datelessDay4.id)!;
+    const remainingDay5 = daysAfter.find(d => d.id === datelessDay5.id)!;
+
+    // Consumed dateless day became dated day 4.
+    expect(remainingDay4.date).toBe('2026-01-04');
+
+    // Unused non-empty dateless day is retained and renumbered after dated range.
+    expect(remainingDay5.date).toBeNull();
+    expect(remainingDay5.day_number).toBe(5);
+    expect(getNotes(remainingDay5.id)).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize dated trips by removing unused empty dateless rows left over after remapping days
- preserve non-empty dateless rows (with assignments/notes/accommodations) to avoid silent data loss
- keep final day numbering compact and collision-safe

## Why
Fixes issue #1083 where trip day_count remained inflated after switching a trip from dateless placeholders to a shorter explicit date range.

## Tests
- added unit regression: dateless(7) -> dated(2) removes stale placeholders
- added unit coverage: dated -> dateless(day_count=X) trims trailing empty days
- added integration regression: API update from dateless(7) to dated(2) returns day_count=2 and stores only 2 day rows
- ran focused tests in server: 74 passed

Closes #1083
