### PR TITLE
Add more bag colors so sub-bags stop repeating

### DIFF
--- a/client/src/components/Packing/packingListPanel.constants.ts
+++ b/client/src/components/Packing/packingListPanel.constants.ts
@@ -45,7 +45,7 @@ export const KAT_COLORS = [
   '#14b8a6', // teal
 ]
 
-export const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b']
+export const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b', '#3b82f6', '#84cc16', '#d946ef', '#14b8a6', '#f43f5e', '#a855f7', '#eab308', '#64748b']
 
 // A category's first item is seeded with this sentinel because the server
 // rejects empty names. Treat it as a placeholder in the UI.

--- a/server/src/services/packingService.ts
+++ b/server/src/services/packingService.ts
@@ -1,7 +1,7 @@
 import { db } from '../db/database';
 import { avatarUrl } from './authService';
 
-const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b'];
+const BAG_COLORS = ['#6366f1', '#ec4899', '#f97316', '#10b981', '#06b6d4', '#8b5cf6', '#ef4444', '#f59e0b', '#3b82f6', '#84cc16', '#d946ef', '#14b8a6', '#f43f5e', '#a855f7', '#eab308', '#64748b'];
 
 export { verifyTripAccess } from './tripAccess';
 


### PR DESCRIPTION
The bag palette only had 8 colors, so the 9th bag reused the first one (reported on Discord). This doubles it to 16 — keeping the existing 8 and their order, and adding 8 more from the same Tailwind family — and keeps the server and client lists in sync (both auto-assign `BAG_COLORS[count % length]`).

Supersedes #1057.
