### PR TITLE
fix(packing): respect per-item quantity in bulk import

### DIFF
--- a/server/src/services/packingService.ts
+++ b/server/src/services/packingService.ts
@@ -76,13 +76,14 @@ interface ImportItem {
   category?: string;
   weight_grams?: string | number;
   bag?: string;
+  quantity?: number;
 }
 
 export function bulkImport(tripId: string | number, items: ImportItem[]) {
   const maxOrder = db.prepare('SELECT MAX(sort_order) as max FROM packing_items WHERE trip_id = ?').get(tripId) as { max: number | null };
   let sortOrder = (maxOrder.max !== null ? maxOrder.max : -1) + 1;
 
-  const stmt = db.prepare('INSERT INTO packing_items (trip_id, name, checked, category, weight_grams, bag_id, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)');
+  const stmt = db.prepare('INSERT INTO packing_items (trip_id, name, checked, category, weight_grams, bag_id, sort_order, quantity) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
   const created: any[] = [];
 
   const insertAll = db.transaction(() => {
@@ -105,7 +106,8 @@ export function bulkImport(tripId: string | number, items: ImportItem[]) {
         }
       }
 
-      const result = stmt.run(tripId, item.name.trim(), checked, item.category?.trim() || 'Other', weight, bagId, sortOrder++);
+      const qty = Math.max(1, Math.min(999, Number(item.quantity) || 1));
+      const result = stmt.run(tripId, item.name.trim(), checked, item.category?.trim() || 'Other', weight, bagId, sortOrder++, qty);
       created.push(db.prepare('SELECT * FROM packing_items WHERE id = ?').get(result.lastInsertRowid));
     }
   });

--- a/server/tests/unit/services/packingService.test.ts
+++ b/server/tests/unit/services/packingService.test.ts
@@ -275,3 +275,27 @@ describe('bulkImport with bag field', () => {
     expect(items[1].bag_id).toBe(bags[0].id);
   });
 });
+
+// ── bulkImport with quantity field ────────────────────────────────────────────
+
+describe('bulkImport with quantity field', () => {
+  it('PACK-SVC-013: bulk import respects per-item quantity, defaults to 1, and clamps out-of-range', () => {
+    const { user } = createUser(testDb);
+    const trip = createTrip(testDb, user.id);
+
+    bulkImport(trip.id, [
+      { name: 'Socks', quantity: 5 },
+      { name: 'Toothbrush' },
+      { name: 'Batteries', quantity: 9999 },
+      { name: 'Charger', quantity: 0 },
+    ]);
+
+    const byName = (n: string) =>
+      testDb.prepare('SELECT * FROM packing_items WHERE trip_id = ? AND name = ?').get(trip.id, n) as any;
+
+    expect(byName('Socks').quantity).toBe(5);
+    expect(byName('Toothbrush').quantity).toBe(1);
+    expect(byName('Batteries').quantity).toBe(999);
+    expect(byName('Charger').quantity).toBe(1);
+  });
+});


### PR DESCRIPTION
## Description
`bulkImport()` ignored the optional `quantity` field, so the MCP `bulk_import_packing` tool (and the REST `POST /trips/:tripId/packing/import` endpoint, which share the same service) always stored a quantity of `1` regardless of what was requested.

The MCP input schema already accepted per-item `quantity` and passed it through; the service was the only place dropping it. This PR adds `quantity` to the bulk INSERT, clamped to `[1, 999]` to match the existing `createItem()` behavior. The DB column, shared Zod schema, MCP schema, and REST controller were already correct, so fixing the service fixes every caller at once.

## Related Issue or Discussion
Closes #1153

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/mauriceboe/TREK/wiki/Contributing)
- [x] My branch is [up to date with `dev`](https://github.com/mauriceboe/TREK/wiki/Development-environment#3-keep-your-fork-up-to-date)
- [x] This PR targets the `dev` branch, not `main` *(wiki-only PRs are exempt)*
- [x] I have tested my changes locally
- [x] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation if needed